### PR TITLE
fix: filter out first beam sequences longer than 30 amino acids

### DIFF
--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -166,6 +166,9 @@ def filter_dataset(dataset: CalibrationDataset) -> CalibrationDataset:
             metadata_predicate=lambda row: row["precursor_charge"] > 6
         )  # Prosit-specific filtering, see https://github.com/Nesvilab/FragPipe/issues/1775
         .filter_entries(
+            predictions_predicate=lambda row: len(row[0].sequence) > 30
+        )  # Prosit-specific filtering
+        .filter_entries(
             predictions_predicate=lambda row: len(row[1].sequence) > 30
         )  # Prosit-specific filtering
     )


### PR DESCRIPTION
A fix for filtering out too-long top sequences to prevent Prosit errors upon running. Previously, this was only implemented for the second sequence on the beam.