### PR TITLE
fix: fix database-ground confidence-cutoff

### DIFF
--- a/winnow/fdr/database_grounded.py
+++ b/winnow/fdr/database_grounded.py
@@ -6,6 +6,7 @@ from instanovo.utils.metrics import Metrics
 from winnow.fdr.base import FDRControl
 from winnow.datasets.calibration_dataset import residue_set
 
+
 class DatabaseGroundedFDRControl(FDRControl):
     """Performs False Discovery Rate (FDR) control by grounding predictions against a reference database.
 
@@ -88,7 +89,7 @@ class DatabaseGroundedFDRControl(FDRControl):
         idx = bisect.bisect_right(self.fdr_thresholds, threshold) - 1
 
         if idx < 0:
-            return None
+            return np.nan
 
         return self.confidence_scores[idx].item()  # type: ignore
 


### PR DESCRIPTION
The previous implementation of `get_confidence_cutoff` used `bisect_left` to find the appropriate confidence score for a given FDR threshold. This was incorrect because it could return an overly conservative confidence score.

In `DatabaseGroundedFDRControl`, FDR is calculated by:
1. Sorting predictions by confidence score in descending order
2. Computing precision at each threshold (correct predictions / total predictions)
3. FDR = 1 - precision
4. Storing these as parallel arrays: `confidence_scores` and `fdr_thresholds`

FDR is a monotonically increasing function as confidence scores decrease:
- Higher confidence scores → Lower FDR
- Lower confidence scores → Higher FDR

This was problematic because:
1. `bisect_left` returns the index where the value would be inserted to maintain order
2. For FDR thresholds, we want the lowest confidence score that gives us an FDR <= threshold
3. `bisect_left` could return an index where the FDR is actually higher than our threshold

For example, if we have the toy setting:
confidence_scores = [0.99, 0.95, 0.8, 0.6]
fdr_thresholds = [0.0, 0.0., 0.05, 0.1]
And we want FDR <= 0.0:
- `bisect_left` would return index 0 (0.99)
- But we actually want index 1 (0.95) because that's the lowest confidence score that gives us FDR <= 0.0.

## Solution
The fix changes the lookup to use `bisect_right` and then subtract 1 from the resultant index.

This works because:
1. `bisect_right` finds the first index where FDR > threshold.
2. We subtract 1 to get the last index where FDR <= threshold.
3. This gives us the lowest confidence score that satisfies our FDR requirement.