### PR TITLE
Feat: switch to gradient boost classifier

### DIFF
--- a/winnow/calibration/calibrator.py
+++ b/winnow/calibration/calibrator.py
@@ -30,7 +30,13 @@ class ProbabilityCalibrator:
         self.dependencies: Dict[str, FeatureDependency] = {}
         self.dependency_reference_counter: Dict[str, int] = {}
         self.classifier = HistGradientBoostingClassifier(
-            learning_rate=0.1, max_depth=3, random_state=seed
+            learning_rate=0.1,
+            max_iter=300,
+            max_leaf_nodes=31,
+            max_depth=5,
+            min_samples_leaf=20,
+            l2_regularization=1.0,
+            random_state=seed,
         )
 
     @property


### PR DESCRIPTION
This PR changes the calibrator model from a logistic regression classifier to a gradient boosted decision tree classifier with tuned hyperparameters.

The model architecture comparison script and the hyperparameter tuning scripts can be found on the feat-change-calibrator branch, and the results are on the project GCS bucket. To summarise, I compared the default versions of the following classifier architectures:
- `GradientBoostingClassifier`,
- `HistGradientBoostingClassifier`,
- `XGBClassifier`,
- `RandomForestClassifier`,
- `ExtraTreesClassifier`,
- `SVC`,
- `LogisticRegression`,
- `KNeighborsClassifier`,
- `MLPClassifier`,
training and validating on the combined validation datasets. I used validation AUC, Brier score and calibration error to choose the best classifier architecture, and HistGradientBoosting performed best in both AUC and Brier score and performed second-best in calibration error. In general, decision tree architectures dominated the comparison.

Furthermore, the `HistGradientBoostingClassifier`:
- scales well with large datasets; 
- has categorical feature support; 
- handles missing values; 
- does not require any additional feature massaging like scaling; 
- has some built-in mechanisms to prevent overfitting, unlike some of the other decision tree architectures considered; and
- allows us to stay within the `sklearn` ecosystem.

I then found the optimal hyperparameter combination by searching over the grid:

```
param_grid: Dict[str, List[Any]] = {
        "learning_rate": [0.01, 0.05, 0.1, 0.5],
        "max_iter": [100, 300, 500, 1000],
        "max_depth": [None, 5, 10, 20, 40],
        "max_leaf_nodes": [None, 15, 31, 63, 127],
        "l2_regularization": [0.0, 0.1, 1.0],
        "min_samples_leaf": [5, 10, 20, 40, 80],
    }
```

using the same metrics and dataset splits. This gave:
- `learning_rate`: 0.1
- `max_iter`: 300
- `max_depth`: 5
- `max_leaf_nodes`: 31
- `l2_regularization`: 1
- `min_samples_leaf`: 20