### PR TITLE
feat: add q-value support

### DIFF
--- a/tests/fdr/test_base.py
+++ b/tests/fdr/test_base.py
@@ -97,17 +97,17 @@ class TestFDRControlBase:
         expected_fdrs = [0.01, 0.02, 0.05, 0.1, 0.2]
         assert list(result_df["psm_fdr"]) == expected_fdrs
 
-    def test_add_psm_qvalue(self, fdr_control, sample_dataframe):
+    def test_add_psm_q_value(self, fdr_control, sample_dataframe):
         """Test adding PSM-specific q-values to DataFrame."""
-        result_df = fdr_control.add_psm_qvalue(sample_dataframe, "confidence")
+        result_df = fdr_control.add_psm_q_value(sample_dataframe, "confidence")
 
-        # Check that psm_qvalue column was added
-        assert "psm_qvalue" in result_df.columns
+        # Check that psm_q_value column was added
+        assert "psm_q_value" in result_df.columns
         assert len(result_df) == len(sample_dataframe)
 
         # Check expected q-values based on our concrete implementation
-        expected_qvalues = [0.01, 0.02, 0.05, 0.1, 0.2]
-        assert list(result_df["psm_qvalue"]) == expected_qvalues
+        expected_q_values = [0.01, 0.02, 0.05, 0.1, 0.2]
+        assert list(result_df["psm_q_value"]) == expected_q_values
 
     def test_get_confidence_curve(self, fdr_control):
         """Test getting confidence curve for FDR thresholds."""

--- a/winnow/fdr/base.py
+++ b/winnow/fdr/base.py
@@ -79,7 +79,7 @@ class FDRControl(metaclass=ABCMeta):
         )
         return dataset_metadata
 
-    def add_psm_qvalue(
+    def add_psm_q_value(
         self, dataset_metadata: pd.DataFrame, confidence_col: str
     ) -> pd.DataFrame:
         """Add PSM-specific q-values as a new column to the dataset.
@@ -117,11 +117,11 @@ class FDRControl(metaclass=ABCMeta):
         q_values.reverse()  # Reverse again to align order with confidence scores
 
         # Add q-values to the sorted dataframe
-        sorted_data["psm_qvalue"] = q_values
+        sorted_data["psm_q_value"] = q_values
 
         # Restore original order by merging back with original dataframe
         result = dataset_metadata.merge(
-            sorted_data[["psm_qvalue"]], left_index=True, right_index=True, how="left"
+            sorted_data[["psm_q_value"]], left_index=True, right_index=True, how="left"
         )
 
         return result

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -209,7 +209,7 @@ def apply_fdr_control(
         dataset.metadata = fdr_control.add_psm_p_value(
             dataset.metadata, confidence_column
         )
-        dataset.metadata = fdr_control.add_psm_qvalue(
+        dataset.metadata = fdr_control.add_psm_q_value(
             dataset.metadata, confidence_column
         )
     else:
@@ -218,7 +218,7 @@ def apply_fdr_control(
             residue_masses=RESIDUE_MASSES,
         )
     dataset.metadata = fdr_control.add_psm_fdr(dataset.metadata, confidence_column)
-    dataset.metadata = fdr_control.add_psm_qvalue(dataset.metadata, confidence_column)
+    dataset.metadata = fdr_control.add_psm_q_value(dataset.metadata, confidence_column)
     confidence_cutoff = fdr_control.get_confidence_cutoff(threshold=fdr_threshold)
     output_data = dataset.metadata
     output_data = output_data[output_data[confidence_column] >= confidence_cutoff]


### PR DESCRIPTION
## Feature: Add q-value estimation support to FDR control framework

### Summary
Added q-value calculation functionality to the FDR control framework, a common metric used by proteomics researchers to assess PSM quality.

### What are q-values?
Q-values represent the minimum false discovery rate at which a given PSM would be considered significant.

### Changes made
- `add_psm_qvalue()` method: Added to the base `FDRControl` class to calculate PSM-specific q-values
- Algorithm implementation: 
  1.   Sort PSMs by confidence scores in descending order
  2.   Calculate FDR for each PSM using existing `compute_fdr()` method
  3.   Traverse from lowest to highest score, maintaining minimum observed FDR
  4.   Assign q-values based on monotonicity constraint
- Integration with main workflow: Updated `apply_fdr_control()` in main script to automatically compute q-values alongside existing FDR calculations