### PR TITLE
Refactor Calibrator Saving to Use Single Pickle File

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -167,9 +167,7 @@ winnow predict \
 Training produces:
 
 1. **Model checkpoints** (in `--model-output-folder`):
-   - `calibrator.pkl`: Trained neural network classifier
-   - `irt_predictor.pkl`: Retention time predictor
-   - `scaler.pkl`: Feature scaler
+   - `calibrator.pkl`: Complete trained calibrator with all features and parameters
 
 2. **Training results** (`--dataset-output-path`):
    - CSV with calibrated scores and evaluation metrics

--- a/tests/calibration/test_calibration_features.py
+++ b/tests/calibration/test_calibration_features.py
@@ -495,7 +495,7 @@ class TestRetentionTimeFeature:
         feature = RetentionTimeFeature(hidden_dim=10, train_fraction=0.8)
         assert feature.hidden_dim == 10
         assert feature.train_fraction == 0.8
-        assert hasattr(feature, "prosit_model")
+        assert feature.prosit_irt_model_name == "Prosit_2019_irt"
         assert hasattr(feature, "irt_predictor")
 
     @patch("winnow.calibration.calibration_features.koinapy.Koina")
@@ -513,9 +513,6 @@ class TestRetentionTimeFeature:
                 "irt": [35.1, 20.7, 28.1, 25.5]  # 4 values for 80% of 5 samples
             }
         )
-
-        # Override the model in the feature
-        retention_time_feature.prosit_model = mock_model_instance
 
         # Mock the MLPRegressor fit method
         with patch.object(retention_time_feature.irt_predictor, "fit") as mock_fit:
@@ -558,9 +555,6 @@ class TestRetentionTimeFeature:
         mock_model_instance.predict.return_value = pd.DataFrame(
             {"irt": [25.5, 30.2, 35.1, 20.7, 28.1]}
         )
-
-        # Override the model in the feature
-        retention_time_feature.prosit_model = mock_model_instance
 
         # Mock the MLPRegressor predict method
         with patch.object(
@@ -657,7 +651,7 @@ class TestPrositFeatures:
         """Test initialization with custom tolerance."""
         feature = PrositFeatures(mz_tolerance=0.01)
         assert feature.mz_tolerance == 0.01
-        assert hasattr(feature, "model")
+        assert feature.prosit_intensity_model_name == "Prosit_2020_intensity_HCD"
 
     def test_prepare_does_nothing(self, prosit_features, sample_dataset_with_spectra):
         """Test that prepare method does nothing."""
@@ -750,9 +744,6 @@ class TestPrositFeatures:
             index=[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2],
         )
         mock_model_instance.predict.return_value = mock_predictions
-
-        # Override the model in the feature
-        prosit_features.model = mock_model_instance
 
         # Mock ion identification computation
         mock_compute_ions.return_value = ([0.5, 0.6, 0.7], [0.4, 0.5, 0.6])

--- a/tests/calibration/test_calibrator.py
+++ b/tests/calibration/test_calibrator.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from pathlib import Path
-from unittest.mock import patch
 from winnow.calibration.calibrator import ProbabilityCalibrator
 from winnow.calibration.calibration_features import (
     CalibrationFeatures,
@@ -271,18 +270,8 @@ class TestProbabilityCalibrator:
         with pytest.raises(NotFittedError):
             calibrator.predict(sample_dataset)
 
-    @patch("pickle.dump")
-    def test_save_creates_directory(self, mock_dump, calibrator, tmp_path):
+    def test_save_creates_directory(self, calibrator, tmp_path):
         """Test saving calibrator creates directory."""
-        # Add a mock RetentionTimeFeature since save() expects it
-        mock_retention_feature = MockCalibrationFeature(
-            "Prosit iRT Features", ["iRT error"]
-        )
-        mock_retention_feature.irt_predictor = (
-            "mock_irt_predictor"  # Add the expected attribute
-        )
-        calibrator.add_feature(mock_retention_feature)
-
         save_path = tmp_path / "test_calibrator"
 
         ProbabilityCalibrator.save(calibrator, save_path)
@@ -290,8 +279,41 @@ class TestProbabilityCalibrator:
         assert save_path.exists()
         assert save_path.is_dir()
         assert (save_path / "calibrator.pkl").exists()
-        assert (save_path / "scaler.pkl").exists()
-        assert (save_path / "irt_predictor.pkl").exists()
+
+    def test_save_and_load_preserves_state(
+        self, calibrator, labelled_dataset, tmp_path
+    ):
+        """Test that save and load preserves all calibrator state including features."""
+        # Add features with specific parameters
+        feature1 = MockCalibrationFeature("test_feature1", ["col1", "col2"])
+        feature2 = MockCalibrationFeature("test_feature2", ["col3"])
+        calibrator.add_feature(feature1)
+        calibrator.add_feature(feature2)
+
+        # Fit the calibrator
+        calibrator.fit(labelled_dataset)
+
+        # Save calibrator
+        save_path = tmp_path / "test_calibrator"
+        ProbabilityCalibrator.save(calibrator, save_path)
+
+        # Load calibrator
+        loaded_calibrator = ProbabilityCalibrator.load(save_path)
+
+        # Verify all state is preserved
+        assert loaded_calibrator.features == calibrator.features
+        assert loaded_calibrator.columns == calibrator.columns
+        assert len(loaded_calibrator.feature_dict) == len(calibrator.feature_dict)
+        assert len(loaded_calibrator.dependencies) == len(calibrator.dependencies)
+
+        # Verify classifier and scaler are fitted
+        assert hasattr(loaded_calibrator.classifier, "classes_")
+        assert hasattr(loaded_calibrator.scaler, "mean_")
+
+        # Verify we can make predictions with loaded calibrator
+        test_dataset = labelled_dataset
+        loaded_calibrator.predict(test_dataset)
+        assert "calibrated_confidence" in test_dataset.metadata.columns
 
     def test_load_nonexistent_path_raises_error(self):
         """Test that loading from nonexistent path raises error."""

--- a/winnow/calibration/calibration_features.py
+++ b/winnow/calibration/calibration_features.py
@@ -198,9 +198,7 @@ class PrositFeatures(CalibrationFeatures):
 
     def __init__(self, mz_tolerance: float) -> None:
         self.mz_tolerance = mz_tolerance
-        self.model = koinapy.Koina(
-            "Prosit_2020_intensity_HCD", "koina.wilhelmlab.org:443"
-        )
+        self.prosit_intensity_model_name = "Prosit_2020_intensity_HCD"
 
     @property
     def dependencies(self) -> List[FeatureDependency]:
@@ -263,7 +261,8 @@ class PrositFeatures(CalibrationFeatures):
         inputs["precursor_charges"] = np.array(dataset.metadata["precursor_charge"])
         inputs["collision_energies"] = np.array(len(dataset.metadata) * [25])
 
-        predictions: pd.DataFrame = self.model.predict(inputs, debug=True)
+        model = koinapy.Koina(self.prosit_intensity_model_name)
+        predictions: pd.DataFrame = model.predict(inputs, debug=True)
         predictions["Index"] = predictions.index
 
         grouped_predictions = predictions.groupby(by="Index").agg(
@@ -306,6 +305,7 @@ class ChimericFeatures(CalibrationFeatures):
 
     def __init__(self, mz_tolerance: float) -> None:
         self.mz_tolerance = mz_tolerance
+        self.prosit_intensity_model_name = "Prosit_2020_intensity_HCD"
 
     @property
     def dependencies(self) -> List[FeatureDependency]:
@@ -375,7 +375,7 @@ class ChimericFeatures(CalibrationFeatures):
         )
         inputs["precursor_charges"] = np.array(dataset.metadata["precursor_charge"])
         inputs["collision_energies"] = np.array(len(dataset.metadata) * [25])
-        model = koinapy.Koina("Prosit_2020_intensity_HCD", "koina.wilhelmlab.org:443")
+        model = koinapy.Koina(self.prosit_intensity_model_name)
         predictions: pd.DataFrame = model.predict(inputs)
         predictions["Index"] = predictions.index
 
@@ -614,7 +614,7 @@ class RetentionTimeFeature(CalibrationFeatures):
     def __init__(self, hidden_dim: int, train_fraction: float) -> None:
         self.train_fraction = train_fraction
         self.hidden_dim = hidden_dim
-        self.prosit_model = koinapy.Koina("Prosit_2019_irt", "koina.wilhelmlab.org:443")
+        self.prosit_irt_model_name = "Prosit_2019_irt"
         self.irt_predictor = MLPRegressor(
             hidden_layer_sizes=[hidden_dim], random_state=42
         )
@@ -675,7 +675,8 @@ class RetentionTimeFeature(CalibrationFeatures):
             ]
         )
         inputs = inputs.set_index(train_data.index)
-        predictions = self.prosit_model.predict(inputs)
+        prosit_model = koinapy.Koina(self.prosit_irt_model_name)
+        predictions = prosit_model.predict(inputs)
         train_data["iRT"] = predictions["irt"]
 
         # -- Fit model
@@ -701,7 +702,8 @@ class RetentionTimeFeature(CalibrationFeatures):
                 for peptide in dataset.metadata["prediction"].apply(map_modification)
             ]
         )
-        predictions = self.prosit_model.predict(inputs)
+        prosit_model = koinapy.Koina(self.prosit_irt_model_name)
+        predictions = prosit_model.predict(inputs)
         dataset.metadata["iRT"] = predictions["irt"]
 
         # - Predict iRT

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -240,8 +240,11 @@ def train(
             help="The path to the config with the specification of the calibration dataset."
         ),
     ],
-    model_output_folder: Annotated[
-        Path, typer.Option(help="The path to write the fitted model checkpoints to.")
+    model_output_dir: Annotated[
+        Path,
+        typer.Option(
+            help="The path to the directory where the fitted model checkpoint will be saved."
+        ),
     ],
     dataset_output_path: Annotated[
         Path, typer.Option(help="The path to write the output to.")
@@ -252,7 +255,7 @@ def train(
     Args:
         data_source (Annotated[ DataSource, typer.Option, optional): The type of PSM dataset to be calibrated.
         dataset_config_path (Annotated[ Path, typer.Option, optional): The path to the config with the specification of the calibration dataset.
-        model_output_folder (Annotated[Path, typer.Option, optional]): The path to write the fitted model checkpoints to.
+        model_output_dir (Annotated[Path, typer.Option, optional]): The path to the directory where the fitted model checkpoint will be saved.
         dataset_output_path (Annotated[Path, typer.Option, optional): The path to write the output to.
     """
     # -- Load dataset
@@ -270,8 +273,8 @@ def train(
     calibrator.fit(annotated_dataset)
 
     # -- Write model checkpoints
-    logger.info(f"Saving model to {model_output_folder}")
-    ProbabilityCalibrator.save(calibrator, model_output_folder)
+    logger.info(f"Saving model to {model_output_dir}")
+    ProbabilityCalibrator.save(calibrator, model_output_dir)
 
     # -- Write output
     logger.info("Writing output.")
@@ -293,8 +296,11 @@ def predict(
             help="The path to the config with the specification of the calibration dataset."
         ),
     ],
-    model_folder: Annotated[
-        Path, typer.Option(help="The path to calibrator checkpoints.")
+    model_dir_path: Annotated[
+        Path,
+        typer.Option(
+            help="The path to the directory containing the calibrator checkpoint."
+        ),
     ],
     method: Annotated[
         FDRMethod, typer.Option(help="Method to use for FDR estimation.")
@@ -315,7 +321,7 @@ def predict(
     Args:
         data_source (Annotated[ DataSource, typer.Option, optional): The type of PSM dataset to be calibrated.
         dataset_config_path (Annotated[ Path, typer.Option, optional): The path to the config with the specification of the dataset.
-        model_folder (Annotated[ Path, typer.Option, optional): The path to calibrator checkpoints.
+        model_dir_path (Annotated[ Path, typer.Option, optional): The path to the directory containing the calibrator checkpoint.
         method (Annotated[ FDRMethod, typer.Option, optional): Method to use for FDR estimation.
         fdr_threshold (Annotated[ float, typer.Option, optional): The target FDR threshold (e.g. 0.01 for 1%, 0.05 for 5% etc.).
         confidence_column (Annotated[ str, typer.Option, optional): Name of the column with confidence scores.
@@ -332,7 +338,7 @@ def predict(
 
     # Predict
     logger.info("Loading calibrator.")
-    calibrator = ProbabilityCalibrator.load(model_folder)
+    calibrator = ProbabilityCalibrator.load(model_dir_path)
 
     logger.info("Calibrating scores.")
     calibrator.predict(dataset)


### PR DESCRIPTION
## Summary

This PR refactors the calibrator saving mechanism to use a single pickle file instead of multiple separate files, ensuring complete parameter preservation and eliminating silent parameter drift issues.

## Problem

The previous approach had a flaw where `ProbabilityCalibrator.load()` would:
1. Load individual pickle files (`calibrator.pkl`, `scaler.pkl`, `irt_predictor.pkl`)
2. Recreate the calibrator with hardcoded default parameters (e.g., `mz_tolerance=0.1`)
3. Assume the default feature set was used during training
4. No way to know what the actual training parameters were

This created a silent parameter mismatch problem where:
- Training might have used `mz_tolerance=0.02` 
- Loading would recreate features with `mz_tolerance=0.1`
- The model would work but with incorrect feature computations

## Solution

**New Approach**: Save the entire `ProbabilityCalibrator` object as one pickle file:
- Single `calibrator.pkl` contains everything
- Complete state preservation including `feature_dict`, `dependencies`, `classifier`, `scaler`
- Runtime Koina model initialization to ensure pickle compatibility

## Key Changes

### 1. Calibrator Implementation (`winnow/calibration/calibrator.py`)
- `save()` method now saves the entire calibrator object
- `load()` method loads the complete state without assumptions
- All parameters preserved exactly as they were during training

### 2. Koina Model Initialization (`winnow/calibration/calibration_features.py`)
- Moved Koina model creation to runtime in `PrositFeatures.compute()`, `ChimericFeatures.compute()` and `RetentionTimeFeature.prepare()`
- Koina model  names preserved in feature objects

### 3. Documentation Updates (`docs/cli.md`)
- Updated to reflect single pickle file approach
- Removed references to separate `scaler.pkl` and `irt_predictor.pkl`

### 4. Test Enhancements (`tests/calibration/test_calibrator.py`)
- Added comprehensive test for state preservation
- Verifies all features, dependencies, classifier, and scaler are preserved
- Ensures loaded calibrator can make predictions

## Benefits

1. **Exact Parameter Preservation**: No more silent parameter drift
2. **Simplified Loading**: One `ProbabilityCalibrator.load()` call gets everything  
3. **No Hardcoded Parameters**: Eliminates risk of mismatched configurations
4. **Self-Contained Models**: Saved models are completely self-describing
5. **Reproducible Inference**: Inference exactly matches training parameters

## Breaking Changes

- **Model Format**: Old multi-file models (`calibrator.pkl` + `scaler.pkl` + `irt_predictor.pkl`) are no longer supported
- **Migration**: Users need to retrain models with the new approach
