### PR TITLE
chore: rename input columns to new instanovo column names

### DIFF
--- a/winnow/datasets/data_loaders.py
+++ b/winnow/datasets/data_loaders.py
@@ -41,8 +41,16 @@ class InstaNovoDatasetLoader(DatasetLoader):
         """
         df = pl.read_csv(predictions_path)
         # Use polars column selectors to split dataframe
-        beam_df = df.select(cs.contains("_beam_"))
-        preds_df = df.select(~cs.contains(["_beam_", "_log_probs_"]))
+        beam_df = df.select(
+            cs.contains(
+                "instanovo_predictions_beam", "instanovo_log_probabilities_beam"
+            )
+        )
+        preds_df = df.select(
+            ~cs.contains(
+                ["instanovo_predictions_beam", "instanovo_log_probabilities_beam"]
+            )
+        )
         return preds_df, beam_df
 
     @staticmethod
@@ -64,9 +72,9 @@ class InstaNovoDatasetLoader(DatasetLoader):
 
             for beam in range(num_beams):
                 seq_col, log_prob_col, token_log_prob_col = (
-                    f"preds_beam_{beam}",
-                    f"log_probs_beam_{beam}",
-                    f"token_log_probs_{beam}",
+                    f"instanovo_predictions_beam_{beam}",
+                    f"instanovo_log_probabilities_beam_{beam}",
+                    f"token_log_probabilities_beam_{beam}",
                 )
                 sequence, log_prob, token_log_prob = (
                     row.get(seq_col),
@@ -91,7 +99,7 @@ class InstaNovoDatasetLoader(DatasetLoader):
             [
                 pl.col(col).str.replace_all("L", "I")
                 for col in beam_df.columns
-                if "preds_beam" in col
+                if "instanovo_predictions_beam" in col
             ]
         )
 
@@ -114,8 +122,8 @@ class InstaNovoDatasetLoader(DatasetLoader):
             pd.DataFrame: The processed dataframe.
         """
         rename_dict = {
-            "preds": "prediction_untokenised",
-            "preds_tokenised": "prediction",
+            "predictions": "prediction_untokenised",
+            "predictions_tokenised": "prediction",
             "log_probs": "confidence",
         }
         if has_labels:


### PR DESCRIPTION
# Update InstaNovo Dataset Loader to Use New Column Names

## Summary

This PR updates the `InstaNovoDatasetLoader` to align with the new InstaNovo column naming conventions.

## Changes

### Column Selector Updates
- Updated `_load_beam_preds()` to use specific InstaNovo column name patterns. Changed from generic `_beam_` pattern matching to explicit `instanovo_predictions_beam` and `instanovo_log_probabilities_beam` patterns

### Beam Processing Column Names
- Updated `_process_beams()` to use new column naming conventions:
  - `preds_beam_{beam}` → `instanovo_predictions_beam_{beam}`
  - `log_probs_beam_{beam}` → `instanovo_log_probabilities_beam_{beam}`
  - `token_log_probs_{beam}` → `token_log_probabilities_beam_{beam}`

### Column Renaming Dictionary
- Updated `_process_predictions()` rename dictionary:
  - `preds` → `predictions`
  - `preds_tokenised` → `predictions_tokenised`
  - `log_probs` → `confidence` (unchanged)

### String Replacement Logic
- Updated the L→I transformation logic to check for `instanovo_predictions_beam` instead of `preds_beam` when identifying columns to process

## Impact

- **Breaking Change**: This change requires InstaNovo output files to use the new column naming conventions. Files using the old column names (`preds_beam_*`, `log_probs_beam_*`, etc.) will no longer be compatible with this loader.
