### PR TITLE
Feat prediction column remapping for instanovo backwards compatibility

### DIFF
--- a/tests/datasets/test_data_loaders.py
+++ b/tests/datasets/test_data_loaders.py
@@ -696,6 +696,98 @@ class TestInstaNovoDatasetLoader:
         assert all(b is not None for b in beams)
 
     # ------------------------------------------------------------------
+    # column_mapping
+    # ------------------------------------------------------------------
+
+    def test_default_column_mapping(self, loader):
+        """Default column_mapping matches the legacy hardcoded values."""
+        assert loader.column_mapping == {
+            "predictions": "predictions",
+            "predictions_tokenised": "predictions_tokenised",
+            "log_probability": "log_probs",
+        }
+
+    def test_custom_column_mapping_overrides_defaults(
+        self, residue_masses, residue_remapping
+    ):
+        """Supplying a column_mapping merges with defaults."""
+        loader = InstaNovoDatasetLoader(
+            residue_masses=residue_masses,
+            residue_remapping=residue_remapping,
+            column_mapping={
+                "predictions": "old_preds",
+                "predictions_tokenised": "old_preds_tok",
+                "log_probability": "old_log_prob",
+            },
+        )
+        assert loader.column_mapping["predictions"] == "old_preds"
+        assert loader.column_mapping["predictions_tokenised"] == "old_preds_tok"
+        assert loader.column_mapping["log_probability"] == "old_log_prob"
+
+    def test_custom_column_mapping_partial_override(
+        self, residue_masses, residue_remapping
+    ):
+        """A partial column_mapping only overrides specified keys."""
+        loader = InstaNovoDatasetLoader(
+            residue_masses=residue_masses,
+            residue_remapping=residue_remapping,
+            column_mapping={"log_probability": "log_probability"},
+        )
+        assert loader.column_mapping["predictions"] == "predictions"
+        assert loader.column_mapping["predictions_tokenised"] == "predictions_tokenised"
+        assert loader.column_mapping["log_probability"] == "log_probability"
+
+    def test_process_predictions_with_custom_column_mapping(
+        self, residue_masses, residue_remapping
+    ):
+        """_process_predictions uses column_mapping to find CSV columns."""
+        loader = InstaNovoDatasetLoader(
+            residue_masses=residue_masses,
+            residue_remapping=residue_remapping,
+            column_mapping={
+                "predictions": "old_preds",
+                "predictions_tokenised": "old_preds_tok",
+                "log_probability": "old_log_prob",
+            },
+        )
+        preds_df = pd.DataFrame(
+            {
+                "spectrum_id": [1],
+                "old_preds": ["PEPTIDE"],
+                "old_preds_tok": ["P, E, P, T, I, D, E"],
+                "old_log_prob": [-0.5],
+            }
+        )
+        result = loader._process_predictions(preds_df, ["spectrum_id"])
+        assert "prediction" in result.columns
+        assert "prediction_untokenised" in result.columns
+        assert "confidence" in result.columns
+
+    def test_process_predictions_raises_with_wrong_column_mapping(
+        self, residue_masses, residue_remapping
+    ):
+        """Missing CSV columns should raise ValueError mentioning column_mapping."""
+        loader = InstaNovoDatasetLoader(
+            residue_masses=residue_masses,
+            residue_remapping=residue_remapping,
+            column_mapping={
+                "predictions": "nonexistent_col",
+                "predictions_tokenised": "predictions_tokenised",
+                "log_probability": "log_probs",
+            },
+        )
+        preds_df = pd.DataFrame(
+            {
+                "spectrum_id": [1],
+                "predictions": ["PEPTIDE"],
+                "predictions_tokenised": ["P, E, P, T, I, D, E"],
+                "log_probs": [-0.5],
+            }
+        )
+        with pytest.raises(ValueError, match="column_mapping"):
+            loader._process_predictions(preds_df, ["spectrum_id"])
+
+    # ------------------------------------------------------------------
     # _process_predictions
     # ------------------------------------------------------------------
 

--- a/winnow/configs/data_loader/instanovo.yaml
+++ b/winnow/configs/data_loader/instanovo.yaml
@@ -41,6 +41,21 @@ residue_remapping:  # Used to map InstaNovo legacy notations to UNIMOD tokens.
 #   predictions_token_log_probabilities_0, predictions_token_log_probabilities_1, predictions_token_log_probabilities_2
 #
 # Set `beam_columns` to null to disable beam loading entirely.
+# Column name mapping for the top-1 predictions CSV.
+#
+# Maps the CSV column names to the internal names used by Winnow.
+# Override these if you are loading predictions from an older InstaNovo version
+# that wrote different column headers.
+#
+# Default CSV column      | Description
+# predictions             | Raw peptide string (top-1)
+# predictions_tokenised   | Tokenised peptide (top-1)
+# log_probs               | Log-probability of the top-1 prediction
+column_mapping:
+  predictions: "predictions"
+  predictions_tokenised: "predictions_tokenised"
+  log_probability: "log_probs"
+
 beam_columns:
   sequence: "predictions_beam_"
   log_probability: "predictions_log_probability_beam_"

--- a/winnow/datasets/data_loaders.py
+++ b/winnow/datasets/data_loaders.py
@@ -32,6 +32,12 @@ from winnow.datasets.calibration_dataset import (
 class InstaNovoDatasetLoader(DatasetLoader):
     """Loader for InstaNovo predictions in CSV format."""
 
+    _DEFAULT_COLUMN_MAPPING: dict[str, str] = {
+        "predictions": "predictions",
+        "predictions_tokenised": "predictions_tokenised",
+        "log_probability": "log_probs",
+    }
+
     def __init__(
         self,
         residue_masses: dict[str, float],
@@ -39,6 +45,7 @@ class InstaNovoDatasetLoader(DatasetLoader):
         isotope_error_range: Tuple[int, int] = (0, 1),
         beam_columns: Optional[dict[str, str]] = None,
         add_index_cols: bool = False,
+        column_mapping: Optional[dict[str, str]] = None,
     ) -> None:
         """Initialise the InstaNovoDatasetLoader.
 
@@ -49,6 +56,11 @@ class InstaNovoDatasetLoader(DatasetLoader):
             beam_columns: The names of the beam columns to substring match in the predictions file.
             add_index_cols: If True, add ``experiment_name`` and ``spectrum_id`` to parquet/ipc
                 inputs. MGF inputs always get these columns regardless of this flag.
+            column_mapping: Mapping from logical column names (``predictions``,
+                ``predictions_tokenised``, ``log_probability``) to the actual CSV column
+                names produced by the InstaNovo version you are loading.  Defaults are
+                ``{"predictions": "predictions", "predictions_tokenised":
+                "predictions_tokenised", "log_probability": "log_probs"}``.
         """
         self.metrics = Metrics(
             residue_set=ResidueSet(
@@ -58,6 +70,10 @@ class InstaNovoDatasetLoader(DatasetLoader):
         )
         self.beam_columns = beam_columns
         self.add_index_cols = add_index_cols
+        self.column_mapping = {
+            **self._DEFAULT_COLUMN_MAPPING,
+            **(column_mapping or {}),
+        }
 
     @staticmethod
     def _df_from_matchms(spectra: list[Spectrum]) -> pl.DataFrame:
@@ -446,16 +462,18 @@ class InstaNovoDatasetLoader(DatasetLoader):
         )
 
         rename_dict = {
-            "predictions": "prediction_untokenised",
-            "predictions_tokenised": "prediction",
-            "log_probs": "confidence",
+            self.column_mapping["predictions"]: "prediction_untokenised",
+            self.column_mapping["predictions_tokenised"]: "prediction",
+            self.column_mapping["log_probability"]: "confidence",
         }
         missing_cols = [
             col for col in rename_dict.keys() if col not in preds_dataset.columns
         ]
         if missing_cols:
             raise ValueError(
-                f"Required columns {missing_cols} not found in predictions dataset."
+                f"Required columns {missing_cols} not found in predictions dataset. "
+                f"If you are using an older InstaNovo version, set column_mapping in "
+                f"the data_loader config to match the CSV headers."
             )
         preds_dataset.rename(rename_dict, axis=1, inplace=True)
 

--- a/winnow/datasets/data_loaders.py
+++ b/winnow/datasets/data_loaders.py
@@ -41,7 +41,7 @@ class InstaNovoDatasetLoader(DatasetLoader):
     def __init__(
         self,
         residue_masses: dict[str, float],
-        residue_remapping: dict[str, str],
+        residue_remapping: Optional[dict[str, str]] = None,
         isotope_error_range: Tuple[int, int] = (0, 1),
         beam_columns: Optional[dict[str, str]] = None,
         add_index_cols: bool = False,


### PR DESCRIPTION
## Summary

Adds configurable prediction column name mapping to `InstaNovoDatasetLoader` for backwards compatibility with older InstaNovo versions that write different CSV column headers. Also makes `residue_remapping` optional.

### Key changes

- **`column_mapping` parameter**: `InstaNovoDatasetLoader` accepts an optional `column_mapping` dict that maps logical column names (`predictions`, `predictions_tokenised`, `log_probability`) to the actual CSV column names. Defaults match the current InstaNovo output (`predictions`, `predictions_tokenised`, `log_probs`). Partial overrides are merged with defaults.
- **Improved error message**: When required CSV columns are missing, the `ValueError` now suggests setting `column_mapping` in the data loader config.
- **Optional `residue_remapping`**: `InstaNovoDatasetLoader.residue_remapping` parameter is now optional (defaults to `None`), simplifying loader construction when no residue remapping is needed.
- **Config**: `data_loader/instanovo.yaml` updated with `column_mapping` block and documentation.
