### PR TITLE
fix: add utils folder to setuptools package list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["winnow", "winnow.scripts", "winnow.fdr", "winnow.datasets", "winnow.calibration", "winnow.compat", "winnow.configs", "winnow.configs.data_loader", "winnow.configs.fdr_method"]
+packages = ["winnow", "winnow.scripts", "winnow.fdr", "winnow.datasets", "winnow.calibration", "winnow.compat", "winnow.configs", "winnow.configs.data_loader", "winnow.configs.fdr_method", "winnow.utils"]
 
 [tool.setuptools.package-data]
 winnow = ["configs/**/*.yaml", "configs/**/*.yml"]


### PR DESCRIPTION
## Description
The `winnow.utils` package was present in the tree but not listed under `[tool.setuptools]` packages, so it was omitted from sdist/wheel installs. That broke imports for anything depending on `winnow.utils` when the project was installed from PyPI or a built wheel.