### PR TITLE
Feat calibration diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Installing Winnow provides the `winnow` command with three sub-commands:
 1. `winnow train` – Performs confidence calibration on a dataset of annotated PSMs, outputting the fitted model checkpoint.
 2. `winnow compute-features` – Computes and outputs the feature set for a dataset of PSMs.
 3. `winnow predict` – Performs confidence calibration using a fitted model checkpoint (defaults to a pretrained general model from Hugging Face), estimates and controls FDR using the calibrated confidence scores.
+4. `winnow diagnose-calibration` – On a labelled holdout, estimates tail calibration error (sTECE/TECE) at the FDR operating threshold and writes a reliability diagram.
 
 By default, `winnow predict` uses a pretrained general model ([`InstaDeepAI/winnow-general-model`](https://huggingface.co/InstaDeepAI/winnow-general-model)) hosted on Hugging Face Hub, allowing you to get started immediately without training. You can also specify custom Hugging Face models or use locally trained models.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Installing Winnow provides the `winnow` command with three sub-commands:
 1. `winnow train` – Performs confidence calibration on a dataset of annotated PSMs, outputting the fitted model checkpoint.
 2. `winnow compute-features` – Computes and outputs the feature set for a dataset of PSMs.
 3. `winnow predict` – Performs confidence calibration using a fitted model checkpoint (defaults to a pretrained general model from Hugging Face), estimates and controls FDR using the calibrated confidence scores.
-4. `winnow diagnose-calibration` – On a labelled holdout, estimates tail calibration error (sTECE/TECE) at the FDR operating threshold and writes a reliability diagram.
+4. `winnow diagnose-calibration` – On a labelled holdout, estimates tail expected calibration error (TECE) and signed tail expected calibration error (sTECE) at the FDR operating threshold and optionally writes a reliability diagram.
 
 By default, `winnow predict` uses a pretrained general model ([`InstaDeepAI/winnow-general-model`](https://huggingface.co/InstaDeepAI/winnow-general-model)) hosted on Hugging Face Hub, allowing you to get started immediately without training. You can also specify custom Hugging Face models or use locally trained models.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Winnow supports two usage modes:
 
 ### CLI
 
-Installing Winnow provides the `winnow` command with three sub-commands:
+Installing Winnow provides the `winnow` command with four sub-commands:
 
 1. `winnow train` – Performs confidence calibration on a dataset of annotated PSMs, outputting the fitted model checkpoint.
 2. `winnow compute-features` – Computes and outputs the feature set for a dataset of PSMs.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -158,8 +158,6 @@ Assess tail calibration on a labelled holdout set before trusting non-parametric
 
 **Configuration:** see [Calibration diagnostic configuration](configuration.md#calibration-diagnostic-configuration) for the full parameter reference.
 
-**Required:** set `diagnostics.label_source` on every run (`sequence` or `precomputed`). There is no automatic label detection.
-
 **Label configuration rules:**
 
 | `label_source` | `label_column` | Behaviour |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,6 +44,9 @@ winnow config predict
 # Show compute-features configuration
 winnow config compute-features
 
+# Show calibration diagnostic configuration
+winnow config diagnose-calibration diagnostics.label_source=sequence
+
 # Check configuration with overrides
 winnow config train data_loader=mztab model_output_dir=models/my_model
 winnow config predict fdr_method=database_grounded fdr_control.fdr_threshold=0.01
@@ -148,6 +151,47 @@ winnow predict calibrator.pretrained_model_name_or_path=models/my_model
 - `output_folder`: Folder path to write output files
 
 By default, `winnow predict` uses the pretrained model `InstaDeepAI/winnow-general-model` from Hugging Face Hub. To use a different model, override the calibrator settings (see [Configuration guide](configuration.md#prediction-configuration) for details).
+
+### `winnow diagnose-calibration`
+
+Assess tail calibration on a labelled holdout set before trusting non-parametric FDR at your operating threshold. The command applies a trained calibrator, derives the confidence cutoff $\tau$ at `fdr_control.fdr_threshold`, estimates signed tail expected calibration error (sTECE) and TECE on $\{S \ge \tau\}$ using isotonic regression, writes a reliability diagram, and warns when $|\widehat{\mathrm{sTECE}}(\tau)|$ exceeds `diagnostics.tolerance` (default `0.005`, i.e. 0.5 percentage points on the FDR scale — about 10% of a 5% FDR target).
+
+**Configuration:** see [Calibration diagnostic configuration](configuration.md#calibration-diagnostic-configuration) for the full parameter reference.
+
+**Required:** set `diagnostics.label_source` on every run (`sequence` or `precomputed`). There is no automatic label detection.
+
+**Label configuration rules:**
+
+| `label_source` | `label_column` | Behaviour |
+| --- | --- | --- |
+| `sequence` | must be unset (`null`) | Derives `correct` from `sequence` and `prediction`. Do not pass `label_column`. |
+| `precomputed` | required (e.g. `proteome_hit`, `correct`) | Uses the given boolean column from predictions/metadata. |
+
+Setting `label_column` while `label_source=sequence` (or omitting `label_column` for `precomputed`) raises an error.
+
+```bash
+# Sequence-derived labels (full match of sequence vs prediction)
+winnow diagnose-calibration diagnostics.label_source=sequence \
+  dataset.spectrum_path_or_directory=holdout/spectra.ipc \
+  dataset.predictions_path=holdout/preds.csv
+
+# Pre-computed labels (e.g. proteome mapping done offline)
+winnow diagnose-calibration \
+  diagnostics.label_source=precomputed diagnostics.label_column=proteome_hit \
+  dataset.predictions_path=holdout/preds_with_hits.csv
+
+# Stricter tolerance for 1% FDR workflows
+winnow diagnose-calibration diagnostics.label_source=sequence diagnostics.tolerance=0.002
+```
+
+**Outputs** (under `diagnostics.output_dir`, default `results/calibration_diagnostic`):
+
+- `diagnostic_report.json` — `conf_cutoff`, `n_tail`, sTECE, TECE, tolerance check, interpretation
+- `reliability_diagram.png` — empirical calibration curve on the operating tail ($S \ge \text{conf\_cutoff}$) vs the identity line
+
+Set `diagnostics.fail_on_warning=true` to exit with code 1 when $|\widehat{\mathrm{sTECE}}| >$ `diagnostics.tolerance` at the operating cutoff (useful in CI).
+
+See also the supplementary theory note in the repository ([`analysis/methods/calibration_fdr_theory.md`](https://github.com/instadeepai/winnow/blob/main/analysis/methods/calibration_fdr_theory.md)).
 
 ## Configuration system
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -154,7 +154,7 @@ By default, `winnow predict` uses the pretrained model `InstaDeepAI/winnow-gener
 
 ### `winnow diagnose-calibration`
 
-Assess tail calibration on a labelled holdout set before trusting non-parametric FDR at your operating threshold. The command applies a trained calibrator, derives the confidence cutoff $\tau$ at `fdr_control.fdr_threshold`, estimates signed tail expected calibration error (sTECE) and TECE on $\{S \ge \tau\}$ using isotonic regression, writes a reliability diagram, and warns when $|\widehat{\mathrm{sTECE}}(\tau)|$ exceeds `diagnostics.tolerance` (default `0.005`, i.e. 0.5 percentage points on the FDR scale — about 10% of a 5% FDR target).
+Assess tail calibration on a labelled holdout set before trusting non-parametric FDR at your operating threshold. The command applies a trained calibrator, derives the confidence cutoff $\tau$ at `fdr_control.fdr_threshold`, estimates signed tail expected calibration error (sTECE) and TECE on $\{S \ge \tau\}$ using isotonic regression, writes a reliability diagram, and warns when $|\widehat{\mathrm{sTECE}}(\tau)|$ exceeds `diagnostics.tolerance` (default `0.005`, i.e. 0.5 percentage points on the FDR scale, which is about 10% of a 5% FDR target).
 
 **Configuration:** see [Calibration diagnostic configuration](configuration.md#calibration-diagnostic-configuration) for the full parameter reference.
 
@@ -191,8 +191,6 @@ winnow diagnose-calibration diagnostics.label_source=sequence diagnostics.tolera
 
 Set `diagnostics.fail_on_warning=true` to exit with code 1 when $|\widehat{\mathrm{sTECE}}| >$ `diagnostics.tolerance` at the operating cutoff (useful in CI).
 
-See also the supplementary theory note in the repository ([`analysis/methods/calibration_fdr_theory.md`](https://github.com/instadeepai/winnow/blob/main/analysis/methods/calibration_fdr_theory.md)).
-
 ## Configuration system
 
 Winnow uses [Hydra](https://hydra.cc/) for configuration management. All parameters can be configured via:
@@ -200,7 +198,6 @@ Winnow uses [Hydra](https://hydra.cc/) for configuration management. All paramet
 - **YAML config files** in the `configs/` directory (defines defaults)
 - **Command-line overrides** using `key=value` syntax
 - **Nested parameters** using dot notation (e.g., `calibrator.seed=42`)
-
 
 For comprehensive configuration documentation, including:
 
@@ -418,7 +415,7 @@ winnow config predict   # View resolved prediction configuration
 This CLI guide focuses on **practical command-line usage**. For other information, see:
 
 | Topic | Documentation |
-|-------|---------------|
+| ------- | --------------- |
 | Configuration system, YAML structure, advanced patterns | [Configuration guide](configuration.md) |
 | Python API, feature implementation, programmatic usage | [API reference](api/calibration.md) |
 | Interactive tutorials and examples | [Examples notebook](https://github.com/instadeepai/winnow/blob/main/examples/getting_started_with_winnow.ipynb) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,8 @@ configs/
 ├── train.yaml                 # Main training config
 ├── compute_features.yaml      # Feature-only export (no MLP fit)
 ├── calibrator.yaml            # Model architecture and features
-└── predict.yaml               # Main prediction config
+├── predict.yaml               # Main prediction config
+└── diagnose_calibration.yaml  # Tail calibration diagnostic (sTECE / TECE)
 ```
 
 ## Overriding configuration
@@ -68,6 +69,10 @@ winnow predict data_loader=mztab fdr_control.fdr_threshold=0.01 fdr_method=datab
 
 # Compute-features overrides
 winnow compute-features dataset_output_path=results/features.csv labelled=false
+
+# Calibration diagnostic overrides
+winnow diagnose-calibration diagnostics.label_source=sequence fdr_control.fdr_threshold=0.01
+winnow diagnose-calibration diagnostics.label_source=precomputed diagnostics.label_column=proteome_hit
 ```
 
 ### Nested parameters
@@ -425,6 +430,67 @@ Requires ground truth sequences in the dataset.
 - `isotope_error_range`: Range of isotope errors to consider when matching peptides
 - `drop`: Number of top predictions to drop for stability
 
+## Calibration diagnostic configuration
+
+### Main config (`configs/diagnose_calibration.yaml`)
+
+Runs tail calibration diagnostics on a labelled holdout set: loads data like `winnow predict`, applies a pretrained calibrator, derives the operating cutoff $\tau$ at `fdr_control.fdr_threshold`, and reports sTECE / TECE on $\{S \ge \tau\}$. See the [CLI reference](cli.md#winnow-diagnose-calibration) for usage examples and interpretation.
+
+```yaml
+defaults:
+  - _self_
+  - residues
+  - data_loader: instanovo
+
+dataset:
+  spectrum_path_or_directory: examples/example_data/spectra.ipc
+  predictions_path: examples/example_data/predictions.csv
+
+calibrator:
+  pretrained_model_name_or_path: InstaDeepAI/winnow-general-model
+  cache_dir: null
+
+fdr_control:
+  fdr_threshold: 0.05
+  confidence_column: calibrated_confidence
+
+diagnostics:
+  label_source: sequence       # sequence | precomputed
+  label_column: null           # required only when label_source=precomputed
+  tolerance: 0.005             # warn if |sTECE| exceeds this (FDR-scale units)
+  min_tail_psms: 100           # minimum PSMs with S >= conf_cutoff for isotonic fit
+  n_bins: 20                   # bins for the reliability diagram
+  output_dir: results/calibration_diagnostic
+  fail_on_warning: false       # exit 1 when |sTECE| > tolerance
+  plot: true
+```
+
+**Key parameters:**
+
+- `data_loader`, `dataset.*`: Same meaning as in `predict.yaml` (holdout spectra + predictions)
+- `calibrator.pretrained_model_name_or_path`, `calibrator.cache_dir`: Calibrator checkpoint to score the holdout (same as predict)
+- `fdr_control.fdr_threshold`: Nominal FDR target $\alpha$ used to set $\tau$ via `NonParametricFDRControl.get_confidence_cutoff`
+- `fdr_control.confidence_column`: Column used for scores $S$ after calibration (default `calibrated_confidence`)
+- `diagnostics.label_source`: How correctness labels $Y$ are obtained (see below)
+- `diagnostics.label_column`: Boolean column name when `label_source=precomputed`; must be `null` when `label_source=sequence`
+- `diagnostics.tolerance`: Maximum acceptable $|\widehat{\mathrm{sTECE}}(\tau)|$ before a warning (default `0.005` ≈ 0.5 pp on the FDR scale at $\alpha=0.05$)
+- `diagnostics.min_tail_psms`: Fail if fewer than this many PSMs remain above $\tau$
+- `diagnostics.n_bins`: Equal-frequency bins for the reliability diagram (tail only, $S \ge \text{conf\_cutoff}$)
+- `diagnostics.output_dir`: Writes `diagnostic_report.json` and `reliability_diagram.png`
+- `diagnostics.fail_on_warning`: If true, non-zero exit when tolerance is exceeded (for CI)
+- `diagnostics.plot`: If false, skip writing the reliability diagram
+
+### Label source (`diagnostics.label_source`)
+
+You must choose exactly one labelling mode. The command validates config before loading data.
+
+| `label_source` | `label_column` | Behaviour |
+| --- | --- | --- |
+| `sequence` | must be `null` | Derive `correct` from full-sequence match of `sequence` vs `prediction` (uses `residue_masses` from `residues.yaml`). |
+| `precomputed` | required (e.g. `proteome_hit`) | Read boolean labels from the named column in merged metadata (e.g. offline proteome mapping). |
+
+Extra label columns in the input file (e.g. `proteome_hit` when using `sequence`) are ignored. If both `sequence` and a precomputed column exist, only the path chosen by `label_source` is used.
+
 ## Shared configuration
 
 ### Residues config (`configs/residues.yaml`)
@@ -616,6 +682,9 @@ winnow config predict
 # View compute-features configuration
 winnow config compute-features
 
+# View calibration diagnostic configuration
+winnow config diagnose-calibration diagnostics.label_source=sequence
+
 # View configuration with overrides
 winnow config train data_loader=mztab model_output_dir=custom/path
 winnow config predict fdr_method=database_grounded fdr_control.fdr_threshold=0.01
@@ -656,6 +725,7 @@ my_configs/
 ├── train.yaml                 # Override training config (if needed)
 ├── compute_features.yaml      # Override compute-features config (if needed)
 ├── predict.yaml               # Override prediction config (if needed)
+├── diagnose_calibration.yaml  # Override calibration diagnostic config (if needed)
 ├── data_loader/               # Override data loaders (if needed)
 │   └── instanovo.yaml
 │   └── mztab.yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -434,7 +434,7 @@ Requires ground truth sequences in the dataset.
 
 ### Main config (`configs/diagnose_calibration.yaml`)
 
-Runs tail calibration diagnostics on a labelled holdout set: loads data like `winnow predict`, applies a pretrained calibrator, derives the operating cutoff $\tau$ at `fdr_control.fdr_threshold`, and reports sTECE / TECE on $\{S \ge \tau\}$. See the [CLI reference](cli.md#winnow-diagnose-calibration) for usage examples and interpretation.
+Runs tail calibration diagnostics on a labelled holdout set: loads data like `winnow predict`, applies a pretrained calibrator, derives the operating cutoff $\tau$ at `fdr_control.fdr_threshold`, and reports sTECE and TECE on $\{S \ge \tau\}$. See the [CLI reference](cli.md#winnow-diagnose-calibration) for usage examples and interpretation.
 
 ```yaml
 defaults:

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,16 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["$", "$"], ["\\(", "\\)"]],
+    displayMath: [["$$", "$$"], ["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,8 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details
+  - pymdownx.arithmatex:
+      generic: true
   - markdown_include.include:
       base_path: '.'
   - toc:
@@ -74,6 +76,10 @@ nav:
     - FDR: api/fdr.md
   - Contributing: contributing.md
   - License: license.md
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "huggingface-hub>=0.35.3",
     "hydra-core>=1.3.2",
     "matchms>=0.31.0",
+    "scikit-learn>=1.3.0",
+    "matplotlib>=3.7.0",
 ]
 
 [project.urls]

--- a/tests/calibration/test_diagnostics.py
+++ b/tests/calibration/test_diagnostics.py
@@ -1,0 +1,194 @@
+"""Unit tests for winnow.calibration.diagnostics."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from winnow.calibration.diagnostics import (
+    SEQUENCE_LABEL_COLUMN,
+    compute_correct_from_sequence,
+    filter_tail,
+    resolve_diagnostics_labels,
+    run_calibration_diagnostic,
+    signed_tail_ece_empirical,
+    signed_tail_ece_isotonic,
+    tail_ece,
+    validate_label_config,
+)
+from winnow.datasets.calibration_dataset import CalibrationDataset
+
+RESIDUE_MASSES = {"A": 71.037114, "G": 57.021464}
+
+
+def _perfectly_calibrated_tail(
+    n: int = 500, conf_cutoff: float = 0.5, seed: int = 0
+) -> tuple:
+    rng = np.random.default_rng(seed)
+    scores = rng.uniform(conf_cutoff, 1.0, size=n)
+    labels = (rng.uniform(size=n) < scores).astype(bool)
+    return scores, labels
+
+
+class TestValidateLabelConfig:
+    def test_sequence_with_label_column_raises(self) -> None:
+        with pytest.raises(ValueError, match="label_column must not be set"):
+            validate_label_config("sequence", "correct")
+
+    def test_precomputed_without_column_raises(self) -> None:
+        with pytest.raises(ValueError, match="label_column is required"):
+            validate_label_config("precomputed", None)
+
+    def test_invalid_source_raises(self) -> None:
+        with pytest.raises(ValueError, match="label_source must be"):
+            validate_label_config("auto", None)
+
+    def test_sequence_without_column_ok(self) -> None:
+        validate_label_config("sequence", None)
+
+    def test_precomputed_with_column_ok(self) -> None:
+        validate_label_config("precomputed", "proteome_hit")
+
+
+class TestComputeCorrectFromSequence:
+    def test_full_sequence_match(self) -> None:
+        meta = pd.DataFrame(
+            {
+                "sequence": [["A", "G"], ["A"]],
+                "prediction": [["A", "G"], ["G"]],
+            }
+        )
+        correct = compute_correct_from_sequence(meta, RESIDUE_MASSES)
+        assert correct.tolist() == [True, False]
+
+
+class TestResolveDiagnosticsLabels:
+    def test_precomputed_proteome_hit(self) -> None:
+        meta = pd.DataFrame(
+            {
+                "spectrum_id": ["a", "b", "c"],
+                "proteome_hit": [True, False, True],
+                "confidence": [0.9, 0.8, 0.7],
+            }
+        )
+        labels, col = resolve_diagnostics_labels(
+            CalibrationDataset(metadata=meta),
+            "precomputed",
+            "proteome_hit",
+            residue_masses=RESIDUE_MASSES,
+        )
+        assert col == "proteome_hit"
+        assert labels.tolist() == [True, False, True]
+
+    def test_sequence_derives_correct(self) -> None:
+        meta = pd.DataFrame(
+            {
+                "spectrum_id": ["a", "b"],
+                "sequence": [["A"], ["A"]],
+                "prediction": [["A"], ["G"]],
+                "proteome_hit": [True, True],
+            }
+        )
+        labels, col = resolve_diagnostics_labels(
+            CalibrationDataset(metadata=meta),
+            "sequence",
+            None,
+            residue_masses=RESIDUE_MASSES,
+        )
+        assert col == SEQUENCE_LABEL_COLUMN
+        assert labels.tolist() == [True, False]
+
+    def test_sequence_ignores_stale_precomputed_column(self) -> None:
+        meta = pd.DataFrame(
+            {
+                "sequence": [["A"], ["A"]],
+                "prediction": [["A"], ["G"]],
+                "correct": [False, True],
+            }
+        )
+        labels, _ = resolve_diagnostics_labels(
+            CalibrationDataset(metadata=meta),
+            "sequence",
+            None,
+            residue_masses=RESIDUE_MASSES,
+        )
+        assert labels.tolist() == [True, False]
+
+    def test_precomputed_missing_column_raises(self) -> None:
+        meta = pd.DataFrame({"confidence": [0.5]})
+        with pytest.raises(ValueError, match="not found"):
+            resolve_diagnostics_labels(
+                CalibrationDataset(metadata=meta),
+                "precomputed",
+                "proteome_hit",
+                residue_masses=RESIDUE_MASSES,
+            )
+
+
+class TestFilterTail:
+    def test_too_few_psms_raises(self) -> None:
+        scores = np.array([0.9, 0.8])
+        labels = np.array([True, False])
+        with pytest.raises(ValueError, match="Only 1 PSMs"):
+            filter_tail(scores, labels, conf_cutoff=0.85, min_tail_psms=10)
+
+
+class TestTailCalibrationMetrics:
+    def test_perfect_calibration_near_zero_stece(self) -> None:
+        scores, labels = _perfectly_calibrated_tail(n=2000, conf_cutoff=0.6)
+        stece = signed_tail_ece_isotonic(scores, labels.astype(float), conf_cutoff=0.6)
+        assert abs(stece) < 0.05
+
+    def test_overconfident_tail_negative_stece(self) -> None:
+        rng = np.random.default_rng(1)
+        n = 1000
+        latent = rng.beta(8, 2, size=n)
+        labels = (rng.uniform(size=n) < latent).astype(bool)
+        scores = np.clip(latent**0.5, 0, 1)
+        stece = signed_tail_ece_isotonic(scores, labels.astype(float), conf_cutoff=0.5)
+        assert stece < -0.02
+
+    def test_tece_bounds_abs_stece(self) -> None:
+        scores, labels = _perfectly_calibrated_tail(n=800, conf_cutoff=0.5)
+        stece = signed_tail_ece_isotonic(scores, labels.astype(float), conf_cutoff=0.5)
+        tece = tail_ece(scores, labels.astype(float), conf_cutoff=0.5)
+        assert tece >= abs(stece) - 1e-9
+
+    def test_empirical_stece_on_tail(self) -> None:
+        scores = np.array([0.9, 0.85, 0.8])
+        labels = np.array([1.0, 0.0, 1.0])
+        stece = signed_tail_ece_empirical(scores, labels, conf_cutoff=0.8)
+        assert stece == pytest.approx(labels.mean() - scores.mean())
+
+
+class TestRunCalibrationDiagnostic:
+    def test_within_tolerance_flag(self) -> None:
+        scores, labels = _perfectly_calibrated_tail(n=1500, conf_cutoff=0.5)
+        result = run_calibration_diagnostic(
+            scores=scores,
+            labels=labels,
+            conf_cutoff=0.5,
+            nominal_fdr=0.05,
+            tolerance=0.5,
+            label_source="sequence",
+            label_column="correct",
+            min_tail_psms=50,
+        )
+        assert result.within_tolerance
+
+    def test_fail_tolerance(self) -> None:
+        scores = np.linspace(0.7, 1.0, 200)
+        labels = np.zeros(200, dtype=bool)
+        result = run_calibration_diagnostic(
+            scores=scores,
+            labels=labels,
+            conf_cutoff=0.7,
+            nominal_fdr=0.05,
+            tolerance=0.001,
+            label_source="precomputed",
+            label_column="correct",
+            min_tail_psms=50,
+        )
+        assert not result.within_tolerance
+        assert result.stece < 0

--- a/tests/calibration/test_diagnostics.py
+++ b/tests/calibration/test_diagnostics.py
@@ -111,6 +111,22 @@ class TestResolveDiagnosticsLabels:
                 residue_masses=RESIDUE_MASSES,
             )
 
+    def test_precomputed_string_labels_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be a boolean or numeric series"):
+            resolve_diagnostics_labels(
+                CalibrationDataset(
+                    metadata=pd.DataFrame(
+                        {
+                            "confidence": [0.5, 0.7, 0.6],
+                            "proteome_hit": ["True", "False", "True"],
+                        }
+                    )
+                ),
+                "precomputed",
+                "proteome_hit",
+                residue_masses=RESIDUE_MASSES,
+            )
+
 
 class TestDiagnosticArrays:
     def test_from_raw_coerces_inputs(self) -> None:

--- a/tests/calibration/test_diagnostics.py
+++ b/tests/calibration/test_diagnostics.py
@@ -8,13 +8,16 @@ import pytest
 
 from winnow.calibration.diagnostics import (
     SEQUENCE_LABEL_COLUMN,
+    DiagnosticArrays,
+    TailSlice,
     compute_correct_from_sequence,
+    empirical_stece,
     filter_tail,
+    fit_isotonic_calibration,
+    isotonic_stece,
+    isotonic_tece,
     resolve_diagnostics_labels,
     run_calibration_diagnostic,
-    signed_tail_ece_empirical,
-    signed_tail_ece_isotonic,
-    tail_ece,
     validate_label_config,
 )
 from winnow.datasets.calibration_dataset import CalibrationDataset
@@ -22,84 +25,67 @@ from winnow.datasets.calibration_dataset import CalibrationDataset
 RESIDUE_MASSES = {"A": 71.037114, "G": 57.021464}
 
 
-def _perfectly_calibrated_tail(
-    n: int = 500, conf_cutoff: float = 0.5, seed: int = 0
-) -> tuple:
-    rng = np.random.default_rng(seed)
-    scores = rng.uniform(conf_cutoff, 1.0, size=n)
-    labels = (rng.uniform(size=n) < scores).astype(bool)
-    return scores, labels
-
-
 class TestValidateLabelConfig:
-    def test_sequence_with_label_column_raises(self) -> None:
-        with pytest.raises(ValueError, match="label_column must not be set"):
-            validate_label_config("sequence", "correct")
+    @pytest.mark.parametrize(
+        ("label_source", "label_column", "error_match"),
+        [
+            ("sequence", "correct", "label_column must not be set"),
+            ("precomputed", None, "label_column is required"),
+            ("auto", None, "label_source must be"),
+        ],
+    )
+    def test_invalid_config_raises(
+        self, label_source: str, label_column: str | None, error_match: str
+    ) -> None:
+        with pytest.raises(ValueError, match=error_match):
+            validate_label_config(label_source, label_column)
 
-    def test_precomputed_without_column_raises(self) -> None:
-        with pytest.raises(ValueError, match="label_column is required"):
-            validate_label_config("precomputed", None)
-
-    def test_invalid_source_raises(self) -> None:
-        with pytest.raises(ValueError, match="label_source must be"):
-            validate_label_config("auto", None)
-
-    def test_sequence_without_column_ok(self) -> None:
-        validate_label_config("sequence", None)
-
-    def test_precomputed_with_column_ok(self) -> None:
-        validate_label_config("precomputed", "proteome_hit")
+    @pytest.mark.parametrize(
+        ("label_source", "label_column"),
+        [
+            ("sequence", None),
+            ("precomputed", "proteome_hit"),
+        ],
+    )
+    def test_valid_config_passes(
+        self, label_source: str, label_column: str | None
+    ) -> None:
+        validate_label_config(label_source, label_column)
 
 
 class TestComputeCorrectFromSequence:
-    def test_full_sequence_match(self) -> None:
-        meta = pd.DataFrame(
-            {
-                "sequence": [["A", "G"], ["A"]],
-                "prediction": [["A", "G"], ["G"]],
-            }
-        )
+    @pytest.mark.parametrize(
+        ("sequence", "prediction", "expected"),
+        [
+            ([["A", "G"], ["A"]], [["A", "G"], ["G"]], [True, False]),
+            (
+                [np.array(["A", "G"], dtype=object)],
+                [np.array(["A", "G"], dtype=object)],
+                [True],
+            ),
+        ],
+    )
+    def test_sequence_correctness(
+        self, sequence: object, prediction: object, expected: list[bool]
+    ) -> None:
+        meta = pd.DataFrame({"sequence": sequence, "prediction": prediction})
         correct = compute_correct_from_sequence(meta, RESIDUE_MASSES)
-        assert correct.tolist() == [True, False]
+        assert correct.tolist() == expected
 
 
 class TestResolveDiagnosticsLabels:
-    def test_precomputed_proteome_hit(self) -> None:
-        meta = pd.DataFrame(
-            {
-                "spectrum_id": ["a", "b", "c"],
-                "proteome_hit": [True, False, True],
-                "confidence": [0.9, 0.8, 0.7],
-            }
-        )
-        labels, col = resolve_diagnostics_labels(
+    def test_precomputed_reads_column(self) -> None:
+        meta = pd.DataFrame({"proteome_hit": [True, False, True]})
+        labels, column = resolve_diagnostics_labels(
             CalibrationDataset(metadata=meta),
             "precomputed",
             "proteome_hit",
             residue_masses=RESIDUE_MASSES,
         )
-        assert col == "proteome_hit"
+        assert column == "proteome_hit"
         assert labels.tolist() == [True, False, True]
 
-    def test_sequence_derives_correct(self) -> None:
-        meta = pd.DataFrame(
-            {
-                "spectrum_id": ["a", "b"],
-                "sequence": [["A"], ["A"]],
-                "prediction": [["A"], ["G"]],
-                "proteome_hit": [True, True],
-            }
-        )
-        labels, col = resolve_diagnostics_labels(
-            CalibrationDataset(metadata=meta),
-            "sequence",
-            None,
-            residue_masses=RESIDUE_MASSES,
-        )
-        assert col == SEQUENCE_LABEL_COLUMN
-        assert labels.tolist() == [True, False]
-
-    def test_sequence_ignores_stale_precomputed_column(self) -> None:
+    def test_sequence_uses_derived_correct_column(self) -> None:
         meta = pd.DataFrame(
             {
                 "sequence": [["A"], ["A"]],
@@ -107,88 +93,114 @@ class TestResolveDiagnosticsLabels:
                 "correct": [False, True],
             }
         )
-        labels, _ = resolve_diagnostics_labels(
+        labels, column = resolve_diagnostics_labels(
             CalibrationDataset(metadata=meta),
             "sequence",
             None,
             residue_masses=RESIDUE_MASSES,
         )
+        assert column == SEQUENCE_LABEL_COLUMN
         assert labels.tolist() == [True, False]
 
     def test_precomputed_missing_column_raises(self) -> None:
-        meta = pd.DataFrame({"confidence": [0.5]})
         with pytest.raises(ValueError, match="not found"):
             resolve_diagnostics_labels(
-                CalibrationDataset(metadata=meta),
+                CalibrationDataset(metadata=pd.DataFrame({"confidence": [0.5]})),
                 "precomputed",
                 "proteome_hit",
                 residue_masses=RESIDUE_MASSES,
             )
 
 
+class TestDiagnosticArrays:
+    def test_from_raw_coerces_inputs(self) -> None:
+        data = DiagnosticArrays.from_raw([0.9, "0.8"], [1, 0])
+        assert data.scores.dtype == np.float64
+        assert data.labels.dtype == bool
+        assert data.scores.tolist() == pytest.approx([0.9, 0.8])
+        assert data.labels.tolist() == [True, False]
+
+    def test_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="same length"):
+            DiagnosticArrays.from_raw([0.9, 0.8], [True])
+
+
 class TestFilterTail:
+    def test_keeps_only_scores_at_or_above_cutoff(self) -> None:
+        data = DiagnosticArrays.from_raw(
+            [0.9, 0.85, 0.4, 0.3], [True, False, True, False]
+        )
+        tail = filter_tail(data, conf_cutoff=0.8, min_tail_psms=1)
+        assert tail.scores.tolist() == pytest.approx([0.9, 0.85])
+        assert tail.labels.tolist() == [True, False]
+
     def test_too_few_psms_raises(self) -> None:
-        scores = np.array([0.9, 0.8])
-        labels = np.array([True, False])
+        data = DiagnosticArrays.from_raw([0.9, 0.8], [True, False])
         with pytest.raises(ValueError, match="Only 1 PSMs"):
-            filter_tail(scores, labels, conf_cutoff=0.85, min_tail_psms=10)
+            filter_tail(data, conf_cutoff=0.85, min_tail_psms=10)
 
 
-class TestTailCalibrationMetrics:
-    def test_perfect_calibration_near_zero_stece(self) -> None:
-        scores, labels = _perfectly_calibrated_tail(n=2000, conf_cutoff=0.6)
-        stece = signed_tail_ece_isotonic(scores, labels.astype(float), conf_cutoff=0.6)
-        assert abs(stece) < 0.05
+class TestEmpiricalStece:
+    def test_known_tail_mean(self) -> None:
+        tail = TailSlice(
+            scores=np.array([1.0, 0.0]),
+            labels=np.array([True, False]),
+        )
+        assert empirical_stece(tail) == pytest.approx(0.0)
 
+
+class TestIsotonicMetrics:
     def test_overconfident_tail_negative_stece(self) -> None:
-        rng = np.random.default_rng(1)
-        n = 1000
-        latent = rng.beta(8, 2, size=n)
-        labels = (rng.uniform(size=n) < latent).astype(bool)
-        scores = np.clip(latent**0.5, 0, 1)
-        stece = signed_tail_ece_isotonic(scores, labels.astype(float), conf_cutoff=0.5)
-        assert stece < -0.02
+        tail = TailSlice(
+            scores=np.linspace(0.7, 1.0, 200),
+            labels=np.zeros(200, dtype=bool),
+        )
+        calibration_curve = fit_isotonic_calibration(tail)
+        assert isotonic_stece(tail, calibration_curve) < 0
 
     def test_tece_bounds_abs_stece(self) -> None:
-        scores, labels = _perfectly_calibrated_tail(n=800, conf_cutoff=0.5)
-        stece = signed_tail_ece_isotonic(scores, labels.astype(float), conf_cutoff=0.5)
-        tece = tail_ece(scores, labels.astype(float), conf_cutoff=0.5)
+        rng = np.random.default_rng(0)
+        scores = rng.uniform(0.5, 1.0, size=800)
+        labels = (rng.uniform(size=800) < scores).astype(bool)
+        tail = TailSlice(scores=scores, labels=labels)
+        calibration_curve = fit_isotonic_calibration(tail)
+        stece = isotonic_stece(tail, calibration_curve)
+        tece = isotonic_tece(tail, calibration_curve)
         assert tece >= abs(stece) - 1e-9
-
-    def test_empirical_stece_on_tail(self) -> None:
-        scores = np.array([0.9, 0.85, 0.8])
-        labels = np.array([1.0, 0.0, 1.0])
-        stece = signed_tail_ece_empirical(scores, labels, conf_cutoff=0.8)
-        assert stece == pytest.approx(labels.mean() - scores.mean())
 
 
 class TestRunCalibrationDiagnostic:
-    def test_within_tolerance_flag(self) -> None:
-        scores, labels = _perfectly_calibrated_tail(n=1500, conf_cutoff=0.5)
-        result = run_calibration_diagnostic(
-            scores=scores,
-            labels=labels,
-            conf_cutoff=0.5,
-            nominal_fdr=0.05,
-            tolerance=0.5,
-            label_source="sequence",
-            label_column="correct",
-            min_tail_psms=50,
+    def test_within_tolerance_follows_isotonic_stece(self) -> None:
+        data = DiagnosticArrays.from_raw(
+            np.linspace(0.7, 1.0, 200),
+            np.zeros(200, dtype=bool),
         )
-        assert result.within_tolerance
-
-    def test_fail_tolerance(self) -> None:
-        scores = np.linspace(0.7, 1.0, 200)
-        labels = np.zeros(200, dtype=bool)
         result = run_calibration_diagnostic(
-            scores=scores,
-            labels=labels,
+            data=data,
             conf_cutoff=0.7,
             nominal_fdr=0.05,
-            tolerance=0.001,
+            tolerance=0.5,
             label_source="precomputed",
             label_column="correct",
             min_tail_psms=50,
         )
-        assert not result.within_tolerance
+        assert result.within_tolerance == (abs(result.stece) <= 0.5)
         assert result.stece < 0
+
+    def test_stece_empirical_uses_filtered_tail(self) -> None:
+        data = DiagnosticArrays.from_raw(
+            [0.9, 0.85, 0.4, 0.3],
+            [True, False, True, False],
+        )
+        result = run_calibration_diagnostic(
+            data=data,
+            conf_cutoff=0.8,
+            nominal_fdr=0.05,
+            tolerance=1.0,
+            label_source="sequence",
+            label_column="correct",
+            min_tail_psms=2,
+        )
+        tail = filter_tail(data, conf_cutoff=0.8, min_tail_psms=1)
+        assert result.stece_empirical == pytest.approx(empirical_stece(tail))
+        assert result.n_tail == len(tail.scores)

--- a/uv.lock
+++ b/uv.lock
@@ -5596,6 +5596,9 @@ dependencies = [
     { name = "instanovo" },
     { name = "koinapy" },
     { name = "matchms" },
+    { name = "matplotlib" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomli" },
     { name = "typer" },
 ]
@@ -5628,6 +5631,8 @@ requires-dist = [
     { name = "instanovo", specifier = ">=1.1.4" },
     { name = "koinapy", specifier = ">=0.0.10" },
     { name = "matchms", specifier = ">=0.31.0" },
+    { name = "matplotlib", specifier = ">=3.7.0" },
+    { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "tomli", specifier = ">=2.2.1" },
     { name = "typer", specifier = ">=0.15.2" },
 ]

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -20,6 +20,34 @@ LabelSource = Literal["sequence", "precomputed"]
 SEQUENCE_LABEL_COLUMN = "correct"
 
 
+@dataclass(frozen=True)
+class DiagnosticArrays:
+    """Aligned confidence scores and boolean correctness labels."""
+
+    scores: NDArray[np.float64]
+    labels: NDArray[np.bool_]
+
+    @classmethod
+    def from_raw(cls, scores: object, labels: object) -> DiagnosticArrays:
+        """Coerce inputs once at the module boundary."""
+        score_array = np.asarray(scores, dtype=np.float64)
+        label_array = np.asarray(labels, dtype=bool)
+        if score_array.shape != label_array.shape:
+            raise ValueError(
+                f"scores and labels must have the same length; "
+                f"got {score_array.shape[0]} and {label_array.shape[0]}."
+            )
+        return cls(scores=score_array, labels=label_array)
+
+
+@dataclass(frozen=True)
+class TailSlice:
+    """Scores and labels restricted to the operating tail S >= conf_cutoff."""
+
+    scores: NDArray[np.float64]
+    labels: NDArray[np.bool_]
+
+
 @dataclass
 class CalibrationDiagnosticResult:
     """Results from a tail calibration diagnostic run."""
@@ -61,6 +89,17 @@ def validate_label_config(
         )
 
 
+def _normalize_peptide_tokens(value: object, metrics: Metrics) -> list[str]:
+    """Normalize a sequence or prediction cell to a list of residue tokens."""
+    if isinstance(value, str):
+        return metrics._split_peptide(value)
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    return []
+
+
 def compute_correct_from_sequence(
     metadata: pd.DataFrame,
     residue_masses: dict[str, float],
@@ -83,18 +122,20 @@ def compute_correct_from_sequence(
         )
     )
     df = metadata.copy()
-    if len(df) > 0 and isinstance(df["sequence"].iloc[0], str):
-        df["sequence"] = df["sequence"].apply(metrics._split_peptide)
-    if len(df) > 0 and isinstance(df["prediction"].iloc[0], str):
-        df["prediction"] = df["prediction"].apply(metrics._split_peptide)
+    df["sequence"] = df["sequence"].apply(
+        lambda value: _normalize_peptide_tokens(value, metrics)
+    )
+    df["prediction"] = df["prediction"].apply(
+        lambda value: _normalize_peptide_tokens(value, metrics)
+    )
 
     def _row_correct(row: pd.Series) -> bool:
-        if not isinstance(row["sequence"], list) or not isinstance(
-            row["prediction"], list
-        ):
+        sequence = row["sequence"]
+        prediction = row["prediction"]
+        if not sequence or not prediction:
             return False
-        num_matches = metrics._novor_match(row["sequence"], row["prediction"])
-        return num_matches == len(row["sequence"]) == len(row["prediction"])
+        num_matches = metrics._novor_match(sequence, prediction)
+        return num_matches == len(sequence) == len(prediction)
 
     return df.apply(_row_correct, axis=1)
 
@@ -133,28 +174,28 @@ def resolve_diagnostics_labels(
 
 
 def filter_tail(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.bool_],
+    data: DiagnosticArrays,
     conf_cutoff: float,
     min_tail_psms: int = 1,
-) -> Tuple[NDArray[np.floating], NDArray[np.bool_]]:
+) -> TailSlice:
     """Restrict scores and labels to the tail S >= conf_cutoff."""
-    mask = scores >= conf_cutoff
+    mask = data.scores >= conf_cutoff
     n_tail = int(mask.sum())
     if n_tail < min_tail_psms:
         raise ValueError(
             f"Only {n_tail} PSMs in the tail (S >= {conf_cutoff:.4f}); "
             f"need at least {min_tail_psms} for a stable isotonic calibration estimate."
         )
-    return scores[mask], labels[mask]
+    return TailSlice(scores=data.scores[mask], labels=data.labels[mask])
 
 
 def empirical_calibration_curve(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.floating],
+    data: DiagnosticArrays | TailSlice,
     n_bins: int = 40,
 ) -> Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.int64]]:
     """Equal-frequency calibration curve. Returns (bin_mean_s, bin_mean_y, bin_weight)."""
+    scores = data.scores
+    labels = data.labels
     order = np.argsort(scores)
     s_sorted = scores[order]
     y_sorted = labels[order]
@@ -175,68 +216,34 @@ def empirical_calibration_curve(
     )
 
 
-def ece(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.floating],
-    n_bins: int = 40,
-) -> float:
-    """Expected calibration error (equal-frequency bins)."""
-    bin_s, bin_y, weights = empirical_calibration_curve(scores, labels, n_bins=n_bins)
-    return float(np.sum(weights * np.abs(bin_s - bin_y)) / weights.sum())
+def empirical_stece(tail: TailSlice) -> float:
+    """Estimate sTECE from pointwise labels on a pre-filtered tail."""
+    return float(tail.labels.mean() - tail.scores.mean())
 
 
-def signed_tail_ece_empirical(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.floating],
-    conf_cutoff: float,
-) -> float:
-    """sTECE(conf_cutoff) = E[c(S) - S | S >= conf_cutoff], estimated from pointwise labels."""
-    mask = scores >= conf_cutoff
-    if not mask.any():
-        return float("nan")
-    return float(labels[mask].mean() - scores[mask].mean())
-
-
-def fit_isotonic_calibration(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.floating],
-) -> IsotonicRegression:
+def fit_isotonic_calibration(tail: TailSlice) -> IsotonicRegression:
     """Fit isotonic regression mapping score -> empirical correctness rate."""
-    iso = IsotonicRegression(out_of_bounds="clip", y_min=0.0, y_max=1.0)
-    iso.fit(scores, labels)
-    return iso
+    calibration_curve = IsotonicRegression(out_of_bounds="clip", y_min=0.0, y_max=1.0)
+    calibration_curve.fit(tail.scores, tail.labels.astype(np.float64))
+    return calibration_curve
 
 
-def signed_tail_ece_isotonic(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.floating],
-    conf_cutoff: float,
-    iso: Optional[IsotonicRegression] = None,
+def isotonic_stece(
+    tail: TailSlice,
+    calibration_curve: IsotonicRegression,
 ) -> float:
     """Compute sTECE via isotonic estimate of c(s): mean(c_hat(s) - s) on the tail."""
-    tail_scores, tail_labels = filter_tail(
-        scores, labels.astype(bool), conf_cutoff, min_tail_psms=1
-    )
-    if iso is None:
-        iso = fit_isotonic_calibration(tail_scores, tail_labels.astype(float))
-    c_hat = iso.predict(tail_scores)
-    return float(np.mean(c_hat - tail_scores))
+    predicted_rate = calibration_curve.predict(tail.scores)
+    return float(np.mean(predicted_rate - tail.scores))
 
 
-def tail_ece(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.floating],
-    conf_cutoff: float,
-    iso: Optional[IsotonicRegression] = None,
+def isotonic_tece(
+    tail: TailSlice,
+    calibration_curve: IsotonicRegression,
 ) -> float:
-    """TECE(conf_cutoff) = E[|c(S) - S| | S >= conf_cutoff] with c estimated isotonically."""
-    tail_scores, tail_labels = filter_tail(
-        scores, labels.astype(bool), conf_cutoff, min_tail_psms=1
-    )
-    if iso is None:
-        iso = fit_isotonic_calibration(tail_scores, tail_labels.astype(float))
-    c_hat = iso.predict(tail_scores)
-    return float(np.mean(np.abs(c_hat - tail_scores)))
+    """TECE on a pre-filtered tail with c estimated isotonically."""
+    predicted_rate = calibration_curve.predict(tail.scores)
+    return float(np.mean(np.abs(predicted_rate - tail.scores)))
 
 
 def _interpret_stece(stece: float) -> str:
@@ -254,44 +261,24 @@ def _interpret_stece(stece: float) -> str:
 
 
 def run_calibration_diagnostic(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.bool_],
+    data: DiagnosticArrays,
     conf_cutoff: float,
     nominal_fdr: float,
     tolerance: float,
     label_source: str,
     label_column: str,
     min_tail_psms: int = 100,
-    n_bins: int = 20,
 ) -> CalibrationDiagnosticResult:
     """Compute tail calibration metrics at the confidence cutoff."""
-    tail_scores, tail_labels = filter_tail(
-        np.asarray(scores, dtype=float),
-        np.asarray(labels, dtype=bool),
-        conf_cutoff,
-        min_tail_psms=min_tail_psms,
-    )
-    labels_f = tail_labels.astype(float)
-    iso = fit_isotonic_calibration(tail_scores, labels_f)
-    stece = signed_tail_ece_isotonic(
-        np.asarray(scores, dtype=float),
-        np.asarray(labels, dtype=bool),
-        conf_cutoff,
-        iso=iso,
-    )
-    tece = tail_ece(
-        np.asarray(scores, dtype=float),
-        np.asarray(labels, dtype=bool),
-        conf_cutoff,
-        iso=iso,
-    )
-    stece_empirical = signed_tail_ece_empirical(
-        np.asarray(scores, dtype=float), labels_f, conf_cutoff
-    )
-    within = abs(stece) <= tolerance
+    tail = filter_tail(data, conf_cutoff, min_tail_psms=min_tail_psms)
+    calibration_curve = fit_isotonic_calibration(tail)
+    stece = isotonic_stece(tail, calibration_curve)
+    tece = isotonic_tece(tail, calibration_curve)
+    stece_empirical = empirical_stece(tail)
+    within_tolerance = abs(stece) <= tolerance
     return CalibrationDiagnosticResult(
         conf_cutoff=float(conf_cutoff),
-        n_tail=int(len(tail_scores)),
+        n_tail=int(len(tail.scores)),
         nominal_fdr=float(nominal_fdr),
         stece=stece,
         tece=tece,
@@ -299,14 +286,13 @@ def run_calibration_diagnostic(
         label_source=label_source,
         label_column=label_column,
         tolerance=tolerance,
-        within_tolerance=within,
+        within_tolerance=within_tolerance,
         interpretation=_interpret_stece(stece),
     )
 
 
 def reliability_diagram(
-    scores: NDArray[np.floating],
-    labels: NDArray[np.floating],
+    data: DiagnosticArrays,
     output_path: Union[Path, str],
     conf_cutoff: float,
     n_bins: int = 20,
@@ -314,15 +300,8 @@ def reliability_diagram(
     """Save a reliability diagram for the operating tail (S >= conf_cutoff)."""
     import matplotlib.pyplot as plt
 
-    tail_scores, tail_labels = filter_tail(
-        np.asarray(scores, dtype=float),
-        np.asarray(labels, dtype=bool),
-        conf_cutoff,
-        min_tail_psms=1,
-    )
-    bin_s, bin_y, _weights = empirical_calibration_curve(
-        tail_scores, tail_labels.astype(float), n_bins=n_bins
-    )
+    tail = filter_tail(data, conf_cutoff, min_tail_psms=1)
+    bin_s, bin_y, _weights = empirical_calibration_curve(tail, n_bins=n_bins)
     fig, ax = plt.subplots(figsize=(5, 5))
     ax.plot([0, 1], [0, 1], "k--", linewidth=1, label="Perfect calibration")
     ax.plot(bin_s, bin_y, "o-", linewidth=1.5, markersize=4, label="Empirical")
@@ -343,8 +322,7 @@ def write_diagnostic_report(
     result: CalibrationDiagnosticResult,
     output_dir: Union[Path, str],
     plot: bool,
-    scores: NDArray[np.floating],
-    labels: NDArray[np.floating],
+    data: DiagnosticArrays,
     n_bins: int,
 ) -> None:
     """Write JSON report and optional reliability diagram."""
@@ -355,8 +333,7 @@ def write_diagnostic_report(
         json.dump(result.to_dict(), fh, indent=2)
     if plot:
         reliability_diagram(
-            scores,
-            labels.astype(float),
+            data,
             out / "reliability_diagram.png",
             conf_cutoff=result.conf_cutoff,
             n_bins=n_bins,

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -1,0 +1,363 @@
+"""Tail calibration diagnostics for non-parametric FDR estimation."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+from instanovo.utils.metrics import Metrics
+from instanovo.utils.residues import ResidueSet
+from numpy.typing import NDArray
+from sklearn.isotonic import IsotonicRegression
+
+from winnow.datasets.calibration_dataset import CalibrationDataset
+
+LabelSource = Literal["sequence", "precomputed"]
+SEQUENCE_LABEL_COLUMN = "correct"
+
+
+@dataclass
+class CalibrationDiagnosticResult:
+    """Results from a tail calibration diagnostic run."""
+
+    conf_cutoff: float
+    n_tail: int
+    nominal_fdr: float
+    stece: float
+    tece: float
+    stece_empirical: float
+    label_source: str
+    label_column: str
+    tolerance: float
+    within_tolerance: bool
+    interpretation: str
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+def validate_label_config(
+    label_source: str,
+    label_column: Optional[str],
+) -> None:
+    """Validate mutual exclusion between label_source and label_column."""
+    if label_source not in ("sequence", "precomputed"):
+        raise ValueError(
+            f"diagnostics.label_source must be 'sequence' or 'precomputed', got {label_source!r}."
+        )
+    if label_source == "sequence" and label_column is not None:
+        raise ValueError(
+            "diagnostics.label_column must not be set when label_source is 'sequence'. "
+            "Sequence-derived labels are written to the 'correct' column automatically."
+        )
+    if label_source == "precomputed" and not label_column:
+        raise ValueError(
+            "diagnostics.label_column is required when label_source is 'precomputed'."
+        )
+
+
+def compute_correct_from_sequence(
+    metadata: pd.DataFrame,
+    residue_masses: dict[str, float],
+    residue_remapping: Optional[dict[str, str]] = None,
+) -> pd.Series:
+    """Derive full-sequence correctness from sequence and prediction columns."""
+    if "sequence" not in metadata.columns:
+        raise ValueError(
+            "label_source='sequence' requires a 'sequence' column in the dataset."
+        )
+    if "prediction" not in metadata.columns:
+        raise ValueError(
+            "label_source='sequence' requires a 'prediction' column in the dataset."
+        )
+
+    metrics = Metrics(
+        residue_set=ResidueSet(
+            residue_masses=residue_masses,
+            residue_remapping=residue_remapping or {},
+        )
+    )
+    df = metadata.copy()
+    if len(df) > 0 and isinstance(df["sequence"].iloc[0], str):
+        df["sequence"] = df["sequence"].apply(metrics._split_peptide)
+    if len(df) > 0 and isinstance(df["prediction"].iloc[0], str):
+        df["prediction"] = df["prediction"].apply(metrics._split_peptide)
+
+    def _row_correct(row: pd.Series) -> bool:
+        if not isinstance(row["sequence"], list) or not isinstance(
+            row["prediction"], list
+        ):
+            return False
+        num_matches = metrics._novor_match(row["sequence"], row["prediction"])
+        return num_matches == len(row["sequence"]) == len(row["prediction"])
+
+    return df.apply(_row_correct, axis=1)
+
+
+def _coerce_bool_labels(series: pd.Series, column: str) -> pd.Series:
+    if series.isna().any():
+        raise ValueError(
+            f"Label column {column!r} contains missing values; "
+            "all PSMs must have a label for calibration diagnostics."
+        )
+    return series.astype(bool)
+
+
+def resolve_diagnostics_labels(
+    dataset: CalibrationDataset,
+    label_source: LabelSource,
+    label_column: Optional[str],
+    residue_masses: dict[str, float],
+    residue_remapping: Optional[dict[str, str]] = None,
+) -> Tuple[pd.Series, str]:
+    """Resolve boolean labels and return (labels, resolved_column_name)."""
+    metadata = dataset.metadata
+
+    if label_source == "precomputed":
+        assert label_column is not None
+        if label_column not in metadata.columns:
+            raise ValueError(
+                f"Precomputed label column {label_column!r} not found in dataset metadata. "
+                f"Available columns: {list(metadata.columns)}"
+            )
+        labels = _coerce_bool_labels(metadata[label_column], label_column)
+        return labels, label_column
+
+    labels = compute_correct_from_sequence(metadata, residue_masses, residue_remapping)
+    return labels, SEQUENCE_LABEL_COLUMN
+
+
+def filter_tail(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.bool_],
+    conf_cutoff: float,
+    min_tail_psms: int = 1,
+) -> Tuple[NDArray[np.floating], NDArray[np.bool_]]:
+    """Restrict scores and labels to the tail S >= conf_cutoff."""
+    mask = scores >= conf_cutoff
+    n_tail = int(mask.sum())
+    if n_tail < min_tail_psms:
+        raise ValueError(
+            f"Only {n_tail} PSMs in the tail (S >= {conf_cutoff:.4f}); "
+            f"need at least {min_tail_psms} for a stable isotonic calibration estimate."
+        )
+    return scores[mask], labels[mask]
+
+
+def empirical_calibration_curve(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.floating],
+    n_bins: int = 40,
+) -> Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.int64]]:
+    """Equal-frequency calibration curve. Returns (bin_mean_s, bin_mean_y, bin_weight)."""
+    order = np.argsort(scores)
+    s_sorted = scores[order]
+    y_sorted = labels[order]
+    edges = np.linspace(0, len(s_sorted), n_bins + 1).astype(int)
+    means_s: list[float] = []
+    means_y: list[float] = []
+    weights: list[int] = []
+    for start, end in zip(edges[:-1], edges[1:]):
+        if end <= start:
+            continue
+        means_s.append(float(s_sorted[start:end].mean()))
+        means_y.append(float(y_sorted[start:end].mean()))
+        weights.append(end - start)
+    return (
+        np.asarray(means_s, dtype=np.float64),
+        np.asarray(means_y, dtype=np.float64),
+        np.asarray(weights, dtype=np.int64),
+    )
+
+
+def ece(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.floating],
+    n_bins: int = 40,
+) -> float:
+    """Expected calibration error (equal-frequency bins)."""
+    bin_s, bin_y, weights = empirical_calibration_curve(scores, labels, n_bins=n_bins)
+    return float(np.sum(weights * np.abs(bin_s - bin_y)) / weights.sum())
+
+
+def signed_tail_ece_empirical(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.floating],
+    conf_cutoff: float,
+) -> float:
+    """sTECE(conf_cutoff) = E[c(S) - S | S >= conf_cutoff], estimated from pointwise labels."""
+    mask = scores >= conf_cutoff
+    if not mask.any():
+        return float("nan")
+    return float(labels[mask].mean() - scores[mask].mean())
+
+
+def fit_isotonic_calibration(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.floating],
+) -> IsotonicRegression:
+    """Fit isotonic regression mapping score -> empirical correctness rate."""
+    iso = IsotonicRegression(out_of_bounds="clip", y_min=0.0, y_max=1.0)
+    iso.fit(scores, labels)
+    return iso
+
+
+def signed_tail_ece_isotonic(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.floating],
+    conf_cutoff: float,
+    iso: Optional[IsotonicRegression] = None,
+) -> float:
+    """Compute sTECE via isotonic estimate of c(s): mean(c_hat(s) - s) on the tail."""
+    tail_scores, tail_labels = filter_tail(
+        scores, labels.astype(bool), conf_cutoff, min_tail_psms=1
+    )
+    if iso is None:
+        iso = fit_isotonic_calibration(tail_scores, tail_labels.astype(float))
+    c_hat = iso.predict(tail_scores)
+    return float(np.mean(c_hat - tail_scores))
+
+
+def tail_ece(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.floating],
+    conf_cutoff: float,
+    iso: Optional[IsotonicRegression] = None,
+) -> float:
+    """TECE(conf_cutoff) = E[|c(S) - S| | S >= conf_cutoff] with c estimated isotonically."""
+    tail_scores, tail_labels = filter_tail(
+        scores, labels.astype(bool), conf_cutoff, min_tail_psms=1
+    )
+    if iso is None:
+        iso = fit_isotonic_calibration(tail_scores, tail_labels.astype(float))
+    c_hat = iso.predict(tail_scores)
+    return float(np.mean(np.abs(c_hat - tail_scores)))
+
+
+def _interpret_stece(stece: float) -> str:
+    if stece < 0:
+        return (
+            "Tail is over-confident: reported FDR likely understates the true error rate "
+            "(more PSMs accepted than the nominal target permits)."
+        )
+    if stece > 0:
+        return (
+            "Tail is under-confident: reported FDR likely overstates the true error rate "
+            "(valid discoveries may be discarded)."
+        )
+    return "Tail calibration residual is near zero at the operating threshold."
+
+
+def run_calibration_diagnostic(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.bool_],
+    conf_cutoff: float,
+    nominal_fdr: float,
+    tolerance: float,
+    label_source: str,
+    label_column: str,
+    min_tail_psms: int = 100,
+    n_bins: int = 20,
+) -> CalibrationDiagnosticResult:
+    """Compute tail calibration metrics at the confidence cutoff."""
+    tail_scores, tail_labels = filter_tail(
+        np.asarray(scores, dtype=float),
+        np.asarray(labels, dtype=bool),
+        conf_cutoff,
+        min_tail_psms=min_tail_psms,
+    )
+    labels_f = tail_labels.astype(float)
+    iso = fit_isotonic_calibration(tail_scores, labels_f)
+    stece = signed_tail_ece_isotonic(
+        np.asarray(scores, dtype=float),
+        np.asarray(labels, dtype=bool),
+        conf_cutoff,
+        iso=iso,
+    )
+    tece = tail_ece(
+        np.asarray(scores, dtype=float),
+        np.asarray(labels, dtype=bool),
+        conf_cutoff,
+        iso=iso,
+    )
+    stece_empirical = signed_tail_ece_empirical(
+        np.asarray(scores, dtype=float), labels_f, conf_cutoff
+    )
+    within = abs(stece) <= tolerance
+    return CalibrationDiagnosticResult(
+        conf_cutoff=float(conf_cutoff),
+        n_tail=int(len(tail_scores)),
+        nominal_fdr=float(nominal_fdr),
+        stece=stece,
+        tece=tece,
+        stece_empirical=stece_empirical,
+        label_source=label_source,
+        label_column=label_column,
+        tolerance=tolerance,
+        within_tolerance=within,
+        interpretation=_interpret_stece(stece),
+    )
+
+
+def reliability_diagram(
+    scores: NDArray[np.floating],
+    labels: NDArray[np.floating],
+    output_path: Union[Path, str],
+    conf_cutoff: float,
+    n_bins: int = 20,
+) -> None:
+    """Save a reliability diagram for the operating tail (S >= conf_cutoff)."""
+    import matplotlib.pyplot as plt
+
+    tail_scores, tail_labels = filter_tail(
+        np.asarray(scores, dtype=float),
+        np.asarray(labels, dtype=bool),
+        conf_cutoff,
+        min_tail_psms=1,
+    )
+    bin_s, bin_y, _weights = empirical_calibration_curve(
+        tail_scores, tail_labels.astype(float), n_bins=n_bins
+    )
+    fig, ax = plt.subplots(figsize=(5, 5))
+    ax.plot([0, 1], [0, 1], "k--", linewidth=1, label="Perfect calibration")
+    ax.plot(bin_s, bin_y, "o-", linewidth=1.5, markersize=4, label="Empirical")
+    ax.set_xlabel("Mean predicted score")
+    ax.set_ylabel("Empirical correctness rate")
+    ax.set_title(rf"Reliability diagram ($S \geq {conf_cutoff:.3f}$)")
+    ax.set_xlim(conf_cutoff, 1.0)
+    ax.set_ylim(0, 1)
+    ax.legend(loc="lower right")
+    fig.tight_layout()
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+
+
+def write_diagnostic_report(
+    result: CalibrationDiagnosticResult,
+    output_dir: Union[Path, str],
+    plot: bool,
+    scores: NDArray[np.floating],
+    labels: NDArray[np.floating],
+    n_bins: int,
+) -> None:
+    """Write JSON report and optional reliability diagram."""
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    report_path = out / "diagnostic_report.json"
+    with open(report_path, "w", encoding="utf-8") as fh:
+        json.dump(result.to_dict(), fh, indent=2)
+    if plot:
+        reliability_diagram(
+            scores,
+            labels.astype(float),
+            out / "reliability_diagram.png",
+            conf_cutoff=result.conf_cutoff,
+            n_bins=n_bins,
+        )

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -9,6 +9,7 @@ from typing import Literal, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_bool_dtype, is_numeric_dtype
 from instanovo.utils.metrics import Metrics
 from instanovo.utils.residues import ResidueSet
 from numpy.typing import NDArray
@@ -147,7 +148,7 @@ def _coerce_bool_labels(series: pd.Series, column: str) -> pd.Series:
             "all PSMs must have a label for calibration diagnostics."
         )
     # Allow only boolean or numeric labels
-    if series.dtype not in [bool, int, float]:
+    if not (is_bool_dtype(series.dtype) or is_numeric_dtype(series.dtype)):
         raise ValueError(
             f"Label column {column!r} must be a boolean or numeric series, got {series.dtype}."
         )

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -146,6 +146,11 @@ def _coerce_bool_labels(series: pd.Series, column: str) -> pd.Series:
             f"Label column {column!r} contains missing values; "
             "all PSMs must have a label for calibration diagnostics."
         )
+    # Allow only boolean or numeric labels
+    if series.dtype not in [bool, int, float]:
+        raise ValueError(
+            f"Label column {column!r} must be a boolean or numeric series, got {series.dtype}."
+        )
     return series.astype(bool)
 
 

--- a/winnow/configs/diagnose_calibration.yaml
+++ b/winnow/configs/diagnose_calibration.yaml
@@ -1,0 +1,30 @@
+# --- Calibration diagnostic (tail sTECE / TECE on a labelled holdout) ---
+defaults:
+  - _self_
+  - residues
+  - data_loader: instanovo
+
+dataset:
+  spectrum_path_or_directory: examples/example_data/spectra.ipc
+  predictions_path: examples/example_data/predictions.csv
+
+calibrator:
+  pretrained_model_name_or_path: InstaDeepAI/winnow-general-model
+  cache_dir: null
+
+fdr_control:
+  fdr_threshold: 0.05
+  confidence_column: calibrated_confidence
+
+diagnostics:
+  # Only one of label_source or label_column can be set.
+  label_source: sequence
+  # Only set when label_source=precomputed (e.g. proteome_hit, correct)
+  label_column: null
+  # |sTECE| warning threshold (~10% of nominal 5% FDR)
+  tolerance: 0.005
+  min_tail_psms: 100
+  n_bins: 20
+  output_dir: results/calibration_diagnostic
+  fail_on_warning: false
+  plot: true

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -399,6 +399,133 @@ def predict_entry_point(
     logger.info("Prediction pipeline completed successfully.")
 
 
+def diagnose_calibration_entry_point(
+    overrides: Optional[List[str]] = None,
+    execute: bool = True,
+    config_dir: Optional[str] = None,
+) -> None:
+    """Run tail calibration diagnostics on a labelled holdout set."""
+    from hydra import initialize_config_dir, compose
+    from hydra.utils import instantiate
+    from omegaconf import OmegaConf
+
+    from winnow.calibration.calibrator import ProbabilityCalibrator
+    from winnow.calibration.diagnostics import (
+        resolve_diagnostics_labels,
+        run_calibration_diagnostic,
+        validate_label_config,
+        write_diagnostic_report,
+    )
+    from winnow.fdr.nonparametric import NonParametricFDRControl
+    from winnow.utils.config_path import get_primary_config_dir
+
+    primary_config_dir = get_primary_config_dir(config_dir)
+
+    with initialize_config_dir(
+        config_dir=str(primary_config_dir),
+        version_base="1.3",
+        job_name="winnow_diagnose_calibration",
+    ):
+        cfg = compose(config_name="diagnose_calibration", overrides=overrides)
+
+    if not execute:
+        print_config(cfg)
+        return
+
+    diag = cfg.diagnostics
+    label_column = diag.label_column if diag.label_column is not None else None
+    validate_label_config(diag.label_source, label_column)
+
+    logger.info("Starting calibration diagnostic pipeline.")
+    logger.info(f"Configuration: {cfg}")
+
+    data_loader = instantiate(cfg.data_loader)
+    dataset_params = dict(cfg.dataset)
+    dataset_params["data_path"] = dataset_params.pop("spectrum_path_or_directory")
+    dataset_params["predictions_path"] = dataset_params.pop("predictions_path", None)
+
+    dataset = data_loader.load(**dataset_params)
+    logger.info(f"Loaded: {len(dataset.metadata)} spectra")
+
+    dataset = filter_dataset(dataset)
+    logger.info(f"After filtering: {len(dataset.metadata)} spectra")
+
+    residue_masses = OmegaConf.to_container(cfg.residue_masses, resolve=True)
+    residue_remapping = OmegaConf.to_container(
+        getattr(cfg.data_loader, "residue_remapping", None) or {}, resolve=True
+    )
+
+    logger.info("Loading trained calibrator.")
+    calibrator = ProbabilityCalibrator.load(
+        pretrained_model_name_or_path=cfg.calibrator.pretrained_model_name_or_path,
+        cache_dir=cfg.calibrator.cache_dir,
+    )
+    logger.info("Calibrating scores.")
+    calibrator.predict(dataset)
+
+    # Resolve labels after predict: feature computation may filter invalid PSMs in place.
+    labels, resolved_label_column = resolve_diagnostics_labels(
+        dataset,
+        diag.label_source,
+        label_column,
+        residue_masses=residue_masses,
+        residue_remapping=residue_remapping,
+    )
+    logger.info(
+        f"Resolved labels via label_source={diag.label_source!r} "
+        f"(column={resolved_label_column!r})."
+    )
+
+    confidence_col = cfg.fdr_control.confidence_column
+    scores = dataset.metadata[confidence_col].to_numpy(dtype=float)
+
+    fdr_control = NonParametricFDRControl()
+    fdr_control.fit(dataset.metadata[confidence_col])
+    conf_cutoff = fdr_control.get_confidence_cutoff(
+        threshold=cfg.fdr_control.fdr_threshold
+    )
+    logger.info(
+        f"Operating confidence cutoff conf_cutoff={conf_cutoff:.4f} "
+        f"at nominal FDR={cfg.fdr_control.fdr_threshold}."
+    )
+
+    result = run_calibration_diagnostic(
+        scores=scores,
+        labels=labels.to_numpy(dtype=bool),
+        conf_cutoff=conf_cutoff,
+        nominal_fdr=cfg.fdr_control.fdr_threshold,
+        tolerance=diag.tolerance,
+        label_source=diag.label_source,
+        label_column=resolved_label_column,
+        min_tail_psms=diag.min_tail_psms,
+        n_bins=diag.n_bins,
+    )
+
+    write_diagnostic_report(
+        result,
+        diag.output_dir,
+        plot=diag.plot,
+        scores=scores,
+        labels=labels.to_numpy(dtype=bool),
+        n_bins=diag.n_bins,
+    )
+    logger.info(f"Wrote diagnostic report to {diag.output_dir}")
+
+    logger.info(
+        f"sTECE={result.stece:.5f}, TECE={result.tece:.5f}, "
+        f"N_tail={result.n_tail}, within_tolerance={result.within_tolerance}"
+    )
+    logger.info(result.interpretation)
+
+    if not result.within_tolerance:
+        logger.warning(
+            f"|sTECE|={abs(result.stece):.5f} exceeds tolerance={diag.tolerance:.5f}. "
+            "Reported FDR may deviate from the realised error rate at this threshold."
+        )
+        if diag.fail_on_warning:
+            raise typer.Exit(code=1)
+
+
 @app.command(
     name="train",
     help=(
@@ -519,6 +646,37 @@ def predict(
     predict_entry_point(overrides, config_dir=config_dir)
 
 
+@app.command(
+    name="diagnose-calibration",
+    help=(
+        "Assess tail calibration of confidence scores on a labelled holdout set.\n\n"
+        "Computes signed tail expected calibration error (sTECE) and TECE at the "
+        "FDR operating threshold, writes a reliability diagram, and warns when "
+        "|sTECE| exceeds `diagnostics.tolerance`.\n\n"
+        "[bold cyan]Required overrides:[/bold cyan]\n"
+        "  [dim]diagnostics.label_source=sequence[/dim]  # derive correct from sequence vs prediction\n"
+        "  [dim]diagnostics.label_source=precomputed diagnostics.label_column=proteome_hit[/dim]\n\n"
+        "[bold cyan]Quick start:[/bold cyan]\n"
+        "  [dim]winnow diagnose-calibration diagnostics.label_source=sequence[/dim]\n"
+    ),
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def diagnose_calibration(
+    ctx: typer.Context,
+    config_dir: Annotated[
+        Optional[str],
+        typer.Option(
+            "--config-dir",
+            "-cp",
+            help="Path to custom config directory (relative or absolute).",
+        ),
+    ] = None,
+) -> None:
+    """Run tail calibration diagnostics on a labelled holdout."""
+    overrides = ctx.args if ctx.args else None
+    diagnose_calibration_entry_point(overrides, config_dir=config_dir)
+
+
 @config_app.command(
     name="train",
     help=(
@@ -607,6 +765,31 @@ def config_predict(
     """Display the resolved prediction configuration."""
     overrides = ctx.args if ctx.args else None
     predict_entry_point(overrides, execute=False, config_dir=config_dir)
+
+
+@config_app.command(
+    name="diagnose-calibration",
+    help=(
+        "Display the resolved diagnose-calibration configuration without running.\n\n"
+        "[bold cyan]Usage:[/bold cyan]\n"
+        "  [dim]winnow config diagnose-calibration diagnostics.label_source=sequence[/dim]\n"
+    ),
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def config_diagnose_calibration(
+    ctx: typer.Context,
+    config_dir: Annotated[
+        Optional[str],
+        typer.Option(
+            "--config-dir",
+            "-cp",
+            help="Path to custom config directory (relative or absolute).",
+        ),
+    ] = None,
+) -> None:
+    """Display the resolved calibration diagnostic configuration."""
+    overrides = ctx.args if ctx.args else None
+    diagnose_calibration_entry_point(overrides, execute=False, config_dir=config_dir)
 
 
 if __name__ == "__main__":

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -411,6 +411,7 @@ def diagnose_calibration_entry_point(
 
     from winnow.calibration.calibrator import ProbabilityCalibrator
     from winnow.calibration.diagnostics import (
+        DiagnosticArrays,
         resolve_diagnostics_labels,
         run_calibration_diagnostic,
         validate_label_config,
@@ -432,9 +433,11 @@ def diagnose_calibration_entry_point(
         print_config(cfg)
         return
 
-    diag = cfg.diagnostics
-    label_column = diag.label_column if diag.label_column is not None else None
-    validate_label_config(diag.label_source, label_column)
+    diagnostics = cfg.diagnostics
+    label_column = (
+        diagnostics.label_column if diagnostics.label_column is not None else None
+    )
+    validate_label_config(diagnostics.label_source, label_column)
 
     logger.info("Starting calibration diagnostic pipeline.")
     logger.info(f"Configuration: {cfg}")
@@ -466,18 +469,21 @@ def diagnose_calibration_entry_point(
     # Resolve labels after predict: feature computation may filter invalid PSMs in place.
     labels, resolved_label_column = resolve_diagnostics_labels(
         dataset,
-        diag.label_source,
+        diagnostics.label_source,
         label_column,
         residue_masses=residue_masses,
         residue_remapping=residue_remapping,
     )
     logger.info(
-        f"Resolved labels via label_source={diag.label_source!r} "
+        f"Resolved labels via label_source={diagnostics.label_source!r} "
         f"(column={resolved_label_column!r})."
     )
 
     confidence_col = cfg.fdr_control.confidence_column
-    scores = dataset.metadata[confidence_col].to_numpy(dtype=float)
+    diagnostic_data = DiagnosticArrays.from_raw(
+        dataset.metadata[confidence_col],
+        labels,
+    )
 
     fdr_control = NonParametricFDRControl()
     fdr_control.fit(dataset.metadata[confidence_col])
@@ -490,26 +496,23 @@ def diagnose_calibration_entry_point(
     )
 
     result = run_calibration_diagnostic(
-        scores=scores,
-        labels=labels.to_numpy(dtype=bool),
+        data=diagnostic_data,
         conf_cutoff=conf_cutoff,
         nominal_fdr=cfg.fdr_control.fdr_threshold,
-        tolerance=diag.tolerance,
-        label_source=diag.label_source,
+        tolerance=diagnostics.tolerance,
+        label_source=diagnostics.label_source,
         label_column=resolved_label_column,
-        min_tail_psms=diag.min_tail_psms,
-        n_bins=diag.n_bins,
+        min_tail_psms=diagnostics.min_tail_psms,
     )
 
     write_diagnostic_report(
         result,
-        diag.output_dir,
-        plot=diag.plot,
-        scores=scores,
-        labels=labels.to_numpy(dtype=bool),
-        n_bins=diag.n_bins,
+        diagnostics.output_dir,
+        plot=diagnostics.plot,
+        data=diagnostic_data,
+        n_bins=diagnostics.n_bins,
     )
-    logger.info(f"Wrote diagnostic report to {diag.output_dir}")
+    logger.info(f"Wrote diagnostic report to {diagnostics.output_dir}")
 
     logger.info(
         f"sTECE={result.stece:.5f}, TECE={result.tece:.5f}, "
@@ -519,10 +522,10 @@ def diagnose_calibration_entry_point(
 
     if not result.within_tolerance:
         logger.warning(
-            f"|sTECE|={abs(result.stece):.5f} exceeds tolerance={diag.tolerance:.5f}. "
+            f"|sTECE| = {abs(result.stece):.5f} exceeds tolerance = {diagnostics.tolerance:.5f}. "
             "Reported FDR may deviate from the realised error rate at this threshold."
         )
-        if diag.fail_on_warning:
+        if diagnostics.fail_on_warning:
             raise typer.Exit(code=1)
 
 

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -454,8 +454,11 @@ def diagnose_calibration_entry_point(
     logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
     residue_masses = OmegaConf.to_container(cfg.residue_masses, resolve=True)
-    residue_remapping = OmegaConf.to_container(
-        getattr(cfg.data_loader, "residue_remapping", None) or {}, resolve=True
+    residue_remapping_cfg = getattr(cfg.data_loader, "residue_remapping", None)
+    residue_remapping = (
+        {}
+        if residue_remapping_cfg is None
+        else OmegaConf.to_container(residue_remapping_cfg, resolve=True)
     )
 
     logger.info("Loading trained calibrator.")


### PR DESCRIPTION
# Description

This PR adds a tail calibration diagnostic workflow for non-parametric FDR (`winnow diagnose-calibration`), and documentation. On a labelled holdout, Winnow calibrates scores, derives the operating confidence cutoff at the nominal FDR target, estimates sTECE and TECE on the tail via isotonic regression, writes a JSON report, and optionally saves a tail-only reliability diagram.
