### PR TITLE
Fix: calibration refactoring and bug fixes

### DIFF
--- a/docs/api/calibration.md
+++ b/docs/api/calibration.md
@@ -94,7 +94,7 @@ The calibrator uses a feature-based approach where multiple feature extractors c
 
 1. **Create Calibrator**: Initialise `ProbabilityCalibrator`
 2. **Add Features**: Use `add_feature()` to include desired calibration features
-3. **Fit Model**: Call `fit()` with labelled `CalibrationDataset`
+3. **Fit Model**: Call `fit()` with a labelled `CalibrationDataset`
 4. **Save Model**: Use `save()` to persist trained calibrator
 
 ### Prediction workflow
@@ -110,7 +110,7 @@ The calibrator uses a feature-based approach where multiple feature extractors c
    # Option 3: Use local model
    calibrator = ProbabilityCalibrator.load("./my_calibrator")
    ```
-2. **Predict**: Call `predict()` with unlabelled `CalibrationDataset`
+2. **Predict**: Call `predict()` with an unlabelled `CalibrationDataset`
 3. **Access Results**: Calibrated scores stored in dataset's "calibrated_confidence" column
 
 For detailed examples and usage patterns, refer to the [examples notebook](https://github.com/instadeepai/winnow/blob/main/examples/getting_started_with_winnow.ipynb).

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -39,6 +39,8 @@ dataset.save(Path("output_directory"))
 
 - **Multiple Format Support**: Load data using specialised loaders for different file formats
 - **Data Integration**: Combines spectral data with prediction metadata
+- **Tokenised Peptides**: Loaders normalise `prediction` (and labelled `sequence`) to token lists and write `valid_prediction` / `valid_sequence` (plus `correct` / `num_matches` when labelled)
+- **Structural Gate**: Direct `CalibrationDataset` construction requires already-tokenised peptide columns.
 - **Filtering**: Removes invalid tokens and unsupported modifications
 - **Evaluation**: Computes correctness labels when ground truth available
 

--- a/docs/api/fdr.md
+++ b/docs/api/fdr.md
@@ -94,7 +94,7 @@ from winnow.fdr import NonParametricFDRControl
 # Create non-parametric FDR controller
 fdr_control = NonParametricFDRControl()
 
-# Fit estimation method to confidence scores
+# Fit estimation method to a Series of confidence scores
 fdr_control.fit(dataset=dataset["confidence"])
 
 # Get confidence cutoff for 5% FDR

--- a/docs/api/fdr.md
+++ b/docs/api/fdr.md
@@ -65,9 +65,9 @@ dataset_with_q_values = fdr_control.add_psm_q_value(dataset, "confidence")
 
 **Required Data:**
 
-- Ground truth peptide sequences (`sequence` column)
-- Predicted peptide sequences (`prediction` column)
 - Confidence scores (configurable column name)
+- Boolean PSM correctness column (`correct`)
+- Boolean ground-truth sequence validity column (`valid_sequence`) used for filtering
 
 ### NonParametricFDRControl
 

--- a/docs/api/fdr.md
+++ b/docs/api/fdr.md
@@ -69,6 +69,27 @@ dataset_with_q_values = fdr_control.add_psm_q_value(dataset, "confidence")
 - Boolean PSM correctness column (`correct`)
 - Boolean ground-truth sequence validity column (`valid_sequence`) used for filtering
 
+**Fit vs apply:**
+
+`fit` builds the FDR curve only from rows with `valid_sequence=True`. Applying a cutoff is score-based only: `get_confidence_cutoff`, `add_psm_fdr`, and `add_psm_q_value` do not require labels, so retained PSMs may include rows that never entered the curve (unlabelled spectra, or `valid_sequence=False`). That is intentional when filtering by confidence alone.
+
+Power users can fit on one labelled dataset and apply the resulting cutoff to another:
+
+```python
+fdr_control.fit(labelled_holdout)
+cutoff = fdr_control.get_confidence_cutoff(threshold=0.01)
+
+# Apply to any dataset that has the confidence column (labels optional)
+target_metadata = fdr_control.add_psm_fdr(
+    target_dataset.metadata, confidence_col="calibrated_confidence"
+)
+retained = target_dataset.filter_entries(
+    metadata_predicate=lambda row: row["calibrated_confidence"] < cutoff
+)
+```
+
+The `winnow predict` CLI still fits and applies on a single labelled input when using database-grounded FDR; use the library API above for transferred cutoffs.
+
 ### NonParametricFDRControl
 
 Uses a label-free, non-parametric method for FDR estimation, specifically designed for scenarios where database ground truth is unavailable.

--- a/docs/api/fdr.md
+++ b/docs/api/fdr.md
@@ -30,33 +30,18 @@ from winnow.fdr.base import FDRControl
 Implements database-grounded FDR control using database search results as ground truth for FDR estimation.
 
 ```python
+from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.fdr import DatabaseGroundedFDRControl
-residue_masses = {
-            "G": 57.021464,
-            "A": 71.037114,
-            "P": 97.052764,
-            "E": 129.042593,
-            "T": 101.047670,
-            "I": 113.084064,
-            "D": 115.026943,
-            "R": 156.101111,
-            "O": 237.147727,
-            "N": 114.042927,
-            "S": 87.032028,
-            "M": 131.040485,
-            "L": 113.084064,
-        }
 
 # Create FDR controller
-fdr_control = DatabaseGroundedFDRControl(confidence_feature="confidence")
-
-# Fit using labelled dataset
-fdr_control.fit(
-    dataset=labelled_dataframe,
-    residue_masses=residue_masses,
-    isotope_error_range=(0, 1),
-    drop=10  # Drop top N predictions for stability
+fdr_control = DatabaseGroundedFDRControl(
+    confidence_feature="confidence",
+    drop=10,  # Drop top N predictions for stability
 )
+
+# Fit using a CalibrationDataset with loader-finalised metadata
+# (requires correct, valid_sequence and confidence columns)
+fdr_control.fit(dataset=calibration_dataset)
 
 # Get confidence cutoff for 1% FDR
 confidence_cutoff = fdr_control.get_confidence_cutoff(threshold=0.01)
@@ -73,10 +58,10 @@ dataset_with_q_values = fdr_control.add_psm_q_value(dataset, "confidence")
 
 **Key Features:**
 
-- **Ground Truth Validation**: Uses database search results for validation
-- **Precision-Recall Analysis**: Computes precision-recall curves from predictions
-- **Isotope Error Handling**: Supports configurable isotope error ranges
+- **Ground Truth Validation**: Uses loader-derived `correct` labels from database-grounded sequences
+- **Precision-Recall Analysis**: Computes precision-recall curves from finalised predictions
 - **Stability Control**: Drop parameter for robust threshold estimation
+- **Finalised Metadata Only**: Does not tokenise peptides or compute match labels; prefer loading labelled data through a DatasetLoader first
 
 **Required Data:**
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -154,7 +154,7 @@ By default, `winnow predict` uses the pretrained model `InstaDeepAI/winnow-gener
 
 ### `winnow diagnose-calibration`
 
-Assess tail calibration on a labelled holdout set before trusting non-parametric FDR at your operating threshold. The command applies a trained calibrator, derives the confidence cutoff $\tau$ at `fdr_control.fdr_threshold`, estimates signed tail expected calibration error (sTECE) and TECE on $\{S \ge \tau\}$ using isotonic regression, writes a reliability diagram, and warns when $|\widehat{\mathrm{sTECE}}(\tau)|$ exceeds `diagnostics.tolerance` (default `0.005`, i.e. 0.5 percentage points on the FDR scale, which is about 10% of a 5% FDR target).
+Assess tail calibration on a labelled holdout set before trusting non-parametric FDR at your operating threshold. The command applies a trained calibrator, derives the confidence cutoff $\tau$ at `fdr_control.fdr_threshold` from the same labelled population used for diagnostics (for `label_source=sequence`, rows with `valid_sequence=True`), estimates signed tail expected calibration error (sTECE) and TECE on $\{S \ge \tau\}$ using isotonic regression, writes a reliability diagram, and warns when $|\widehat{\mathrm{sTECE}}(\tau)|$ exceeds `diagnostics.tolerance` (default `0.005`, i.e. 0.5 percentage points on the FDR scale, which is about 10% of a 5% FDR target).
 
 **Configuration:** see [Calibration diagnostic configuration](configuration.md#calibration-diagnostic-configuration) for the full parameter reference.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -413,18 +413,14 @@ No additional parameters required.
 ```yaml
 _target_: winnow.fdr.database_grounded.DatabaseGroundedFDRControl
 confidence_feature: ${fdr_control.confidence_column}
-residue_masses: ${residue_masses}
-isotope_error_range: [0, 1]
 drop: 10
 ```
 
-Requires ground truth sequences in the dataset.
+Requires finalised labelled metadata from a DatasetLoader (`correct` and `valid_sequence`).
 
 **Key parameters:**
 
 - `confidence_feature`: Name of the column with confidence scores (interpolated from fdr_control)
-- `residue_masses`: Amino acid and modification masses (interpolated from residues config)
-- `isotope_error_range`: Range of isotope errors to consider when matching peptides
 - `drop`: Number of top predictions to drop for stability
 
 ## Calibration diagnostic configuration
@@ -483,7 +479,7 @@ You must choose exactly one labelling mode. The command validates config before 
 
 | `label_source` | `label_column` | Behaviour |
 | --- | --- | --- |
-| `sequence` | must be `null` | Derive `correct` from full-sequence match of `sequence` vs `prediction` (uses `residue_masses` from `residues.yaml`). |
+| `sequence` | must be `null` | Use loader-finalised `correct` labels (and exclude rows with `valid_sequence=False`). |
 | `precomputed` | required (e.g. `proteome_hit`) | Read boolean labels from the named column in merged metadata (e.g. offline proteome mapping). |
 
 Extra label columns in the input file (e.g. `proteome_hit` when using `sequence`) are ignored. If both `sequence` and a precomputed column exist, only the path chosen by `label_source` is used.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -427,7 +427,7 @@ Requires finalised labelled metadata from a DatasetLoader (`correct` and `valid_
 
 ### Main config (`configs/diagnose_calibration.yaml`)
 
-Runs tail calibration diagnostics on a labelled holdout set: loads data like `winnow predict`, applies a pretrained calibrator, derives the operating cutoff $\tau$ at `fdr_control.fdr_threshold`, and reports sTECE and TECE on $\{S \ge \tau\}$. See the [CLI reference](cli.md#winnow-diagnose-calibration) for usage examples and interpretation.
+Runs tail calibration diagnostics on a labelled holdout set: loads data like `winnow predict`, applies a pretrained calibrator, derives the operating cutoff $\tau$ at `fdr_control.fdr_threshold` on the labelled diagnostic population, and reports sTECE and TECE on $\{S \ge \tau\}$. See the [CLI reference](cli.md#winnow-diagnose-calibration) for usage examples and interpretation.
 
 ```yaml
 defaults:

--- a/tests/calibration/features/test_base.py
+++ b/tests/calibration/features/test_base.py
@@ -56,7 +56,9 @@ class TestConcreteFeatureImplementation:
     def test_concrete_feature_compute(self):
         """Test that concrete feature can compute values."""
         feature = ConcreteFeature()
-        metadata = pd.DataFrame({"existing_col": [1, 2, 3]})
+        metadata = pd.DataFrame(
+            {"existing_col": [1, 2, 3], "prediction": [["A"], ["G"], ["K"]]}
+        )
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         feature.compute(dataset)

--- a/tests/calibration/features/test_beam.py
+++ b/tests/calibration/features/test_beam.py
@@ -20,7 +20,9 @@ class TestBeamFeatures:
     @pytest.fixture()
     def sample_dataset_with_predictions(self):
         """Create a sample dataset with beam search predictions."""
-        metadata = pd.DataFrame({"confidence": [0.9, 0.8, 0.7]})
+        metadata = pd.DataFrame(
+            {"confidence": [0.9, 0.8, 0.7], "prediction": [["A"], ["G"], ["K"]]}
+        )
 
         # Mock beam search results with different numbers of sequences
         predictions = [
@@ -79,7 +81,7 @@ class TestBeamFeatures:
 
     def test_compute_with_none_predictions(self, beam_features):
         """Test that compute raises error when predictions is None."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         with pytest.raises(
@@ -90,7 +92,9 @@ class TestBeamFeatures:
 
     def test_compute_with_insufficient_sequences_warning(self, beam_features):
         """Test that warning is issued for beam results with < 2 sequences."""
-        metadata = pd.DataFrame({"confidence": [0.9, 0.8]})
+        metadata = pd.DataFrame(
+            {"confidence": [0.9, 0.8], "prediction": [["A"], ["G"]]}
+        )
         predictions = [
             [MockScoredSequence(["A"], np.log(0.8))],  # Only 1 sequence
             [
@@ -108,7 +112,7 @@ class TestBeamFeatures:
 
     def test_margin_calculation(self, beam_features):
         """Test specific margin calculation."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [
                 MockScoredSequence(["A"], np.log(0.8)),  # top = 0.8
@@ -126,7 +130,7 @@ class TestBeamFeatures:
 
     def test_beam_features_with_one_sequence(self, beam_features):
         """Test beam feature calculations with single sequence."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [MockScoredSequence(["A"], np.log(0.8))]  # Single sequence
         ]
@@ -164,7 +168,7 @@ class TestBeamFeatures:
 
     def test_beam_features_with_two_sequences(self, beam_features):
         """Test beam feature calculations with two sequences."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [
                 MockScoredSequence(["A"], np.log(0.8)),  # top
@@ -205,7 +209,7 @@ class TestBeamFeatures:
 
     def test_beam_features_with_three_sequences(self, beam_features):
         """Test beam feature calculations with three sequences."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [
                 MockScoredSequence(["A"], np.log(0.7)),  # top
@@ -245,7 +249,7 @@ class TestBeamFeatures:
 
     def test_beam_features_edge_case_equal_probabilities(self, beam_features):
         """Test beam features when all sequences have equal probabilities."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [
                 MockScoredSequence(["A"], np.log(1 / 3)),
@@ -276,7 +280,7 @@ class TestBeamFeatures:
 
     def test_beam_features_raises_for_none_predictions(self, beam_features):
         """BeamFeatures.compute should raise ValueError when predictions is None."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         with pytest.raises(ValueError, match="BeamFeatures requires beam predictions"):

--- a/tests/calibration/features/test_chimeric.py
+++ b/tests/calibration/features/test_chimeric.py
@@ -30,6 +30,7 @@ class TestChimericFeatures:
         metadata = pd.DataFrame(
             {
                 "confidence": [0.9, 0.8, 0.7],
+                "prediction": [["A", "G"], ["V", "T"], ["K"]],
                 "precursor_charge": [2, 2, 3],
                 "spectrum_id": [0, 1, 2],
                 "mz_array": [
@@ -168,7 +169,9 @@ class TestChimericFeatures:
 
     def test_compute_with_none_predictions(self, chimeric_features):
         """Test that compute raises error when predictions is None."""
-        metadata = pd.DataFrame({"confidence": [0.9], "precursor_charge": [2]})
+        metadata = pd.DataFrame(
+            {"confidence": [0.9], "prediction": [["A"]], "precursor_charge": [2]}
+        )
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         with pytest.raises(
@@ -182,6 +185,7 @@ class TestChimericFeatures:
         metadata = pd.DataFrame(
             {
                 "confidence": [0.9],
+                "prediction": [["A"]],
                 "precursor_charge": [2],
             }
         )
@@ -302,6 +306,7 @@ class TestChimericFeatures:
         metadata = pd.DataFrame(
             {
                 "confidence": [0.9, 0.7, 0.6],
+                "prediction": [["A", "G"], ["K"], ["S", "P"]],
                 "precursor_charge": [2, 2, 7],  # Last one has charge > 6
                 "spectrum_id": [10, 30, 40],
                 "mz_array": [
@@ -372,6 +377,7 @@ class TestChimericFeatures:
         )
         metadata = pd.DataFrame(
             {
+                "prediction": [["A", "G"], ["V", "T"], ["S", "P"]],
                 "precursor_charge": [2, 2, 2],
                 "spectrum_id": [10, 20, 30],
                 "mz_array": [[100.0, 200.0], [120.0], [110.0, 210.0]],

--- a/tests/calibration/features/test_mass_error.py
+++ b/tests/calibration/features/test_mass_error.py
@@ -167,21 +167,6 @@ class TestMassErrorPPMFeature:
         result = dataset.metadata.iloc[0]["mass_error_ppm"]
         assert result < 0
 
-    def test_compute_with_invalid_peptide(self, residue_masses):
-        """When prediction is not a list, compute should raise."""
-        feature = MassErrorPPMFeature(residue_masses=residue_masses)
-        metadata = pd.DataFrame(
-            {
-                "precursor_mz": [500.503638],
-                "precursor_charge": [2],
-                "prediction": ["invalid_string"],
-            }
-        )
-        dataset = CalibrationDataset(metadata=metadata, predictions=None)
-
-        with pytest.raises(ValueError, match="not valid peptide sequences"):
-            feature.compute(dataset)
-
     def test_custom_residue_masses(self):
         """Test that custom residue masses are used correctly."""
         custom_masses = {"A": 100.0, "G": 200.0}
@@ -333,21 +318,6 @@ class TestMassErrorDaFeature:
 
         result = dataset.metadata.iloc[0]["mass_error_da"]
         assert result < 0
-
-    def test_compute_with_invalid_peptide(self, residue_masses):
-        """When prediction is not a list, compute should raise."""
-        feature = MassErrorDaFeature(residue_masses=residue_masses)
-        metadata = pd.DataFrame(
-            {
-                "precursor_mz": [500.503638],
-                "precursor_charge": [2],
-                "prediction": ["invalid_string"],
-            }
-        )
-        dataset = CalibrationDataset(metadata=metadata, predictions=None)
-
-        with pytest.raises(ValueError, match="not valid peptide sequences"):
-            feature.compute(dataset)
 
     def test_custom_residue_masses(self):
         """Test that custom residue masses are used correctly."""

--- a/tests/calibration/features/test_retention_time.py
+++ b/tests/calibration/features/test_retention_time.py
@@ -236,19 +236,128 @@ class TestRetentionTimeFeature:
 
         metadata = pd.DataFrame(
             {
-                "confidence": [0.95, 0.90],
-                "prediction": [["A", "G"], ["G", "A"]],
-                "retention_time": [10.5, 15.2],
-                "spectrum_id": [0, 1],
-                "experiment_name": ["exp_a", "exp_a"],
+                "confidence": [0.95 - 0.01 * i for i in range(20)],
+                "prediction": [
+                    ["A", "G"] if i % 2 == 0 else ["G", "A"] for i in range(20)
+                ],
+                "retention_time": [10.5 + i for i in range(20)],
+                "spectrum_id": list(range(20)),
+                "experiment_name": ["exp_a"] * 20,
             }
         )
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         feature = RetentionTimeFeature(train_fraction=0.1, min_train_points=10)
 
-        with pytest.raises(ValueError, match="insufficient data for iRT"):
+        with pytest.raises(
+            ValueError,
+            match=r"Experiment 'exp_a'.*insufficient data for iRT calibration",
+        ):
             feature.prepare(dataset)
+
+    def test_select_training_data_errors_on_single_unique_peptide(self):
+        """Raise when duplicate peptides yield a single Koina iRT target."""
+        feature = RetentionTimeFeature(
+            train_fraction=1.0,
+            min_train_points=2,
+            learn_from_missing=False,
+        )
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.95, 0.90, 0.85, 0.80, 0.75, 0.70],
+                "prediction": [["A", "G"]] * 6,
+                "retention_time": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                "spectrum_id": list(range(6)),
+            }
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"(?s)Experiment 'exp_a': Cannot fit iRT calibration regressor\."
+                r".*Training pool has only 1 unique peptide\(s\).*"
+                r"Koina iRT prediction models output one iRT per peptide sequence"
+            ),
+        ):
+            feature._select_training_data(metadata, "exp_a")
+
+    def test_select_training_data_warns_on_partial_sequence_diversity(self):
+        """Warn when unique sequences are above 2 but below min_train_points."""
+        feature = RetentionTimeFeature(
+            train_fraction=1.0,
+            min_train_points=5,
+            learn_from_missing=False,
+        )
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.95, 0.90, 0.85, 0.80, 0.75, 0.70],
+                "prediction": [
+                    ["A", "G"],
+                    ["A", "G"],
+                    ["G", "A"],
+                    ["G", "A"],
+                    ["L", "K"],
+                    ["M", "V"],
+                ],
+                "retention_time": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                "spectrum_id": list(range(6)),
+            }
+        )
+
+        with pytest.warns(
+            UserWarning, match=r"unique peptide\(s\), below min_train_points"
+        ):
+            train_data = feature._select_training_data(metadata, "exp_a")
+
+        assert len(train_data) == 6
+
+    def test_select_training_data_errors_on_single_retention_time(self):
+        """Raise when the calibration pool has no RT spread for linear regression."""
+        feature = RetentionTimeFeature(
+            train_fraction=1.0,
+            min_train_points=2,
+            learn_from_missing=False,
+        )
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.95, 0.90, 0.85],
+                "prediction": [["A", "G"], ["G", "A"], ["S", "P"]],
+                "retention_time": [10.0, 10.0, 10.0],
+                "spectrum_id": [0, 1, 2],
+            }
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"(?s)Experiment 'exp_a': Cannot fit iRT calibration regressor\."
+                r".*unique retention time value\(s\)"
+            ),
+        ):
+            feature._select_training_data(metadata, "exp_a")
+
+    @patch("winnow.calibration.features.retention_time.koinapy.Koina")
+    def test_compute_skips_koina_when_no_valid_spectra(self, mock_koina):
+        """Do not call Koina when every spectrum is invalid for iRT prediction."""
+        mock_model_instance = Mock()
+        mock_koina.return_value = mock_model_instance
+        mock_model_instance.model_inputs = ["peptide_sequences"]
+
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.95, 0.90],
+                "prediction": [["A"] * 31, ["G"] * 31],
+                "retention_time": [10.5, 15.2],
+                "spectrum_id": [0, 1],
+            }
+        )
+        dataset = CalibrationDataset(metadata=metadata, predictions=None)
+        feature = RetentionTimeFeature(max_peptide_length=30)
+
+        feature.compute(dataset)
+
+        mock_model_instance.predict.assert_not_called()
+        assert dataset.metadata["irt_error"].tolist() == [0.0, 0.0]
 
     @patch("winnow.calibration.features.retention_time.koinapy.Koina")
     def test_compute_with_mock(
@@ -437,10 +546,22 @@ class TestRetentionTimeFeature:
 
         assert feature.min_train_points == 10
 
+        unique_predictions = [
+            ["A", "G"],
+            ["G", "A"],
+            ["S", "P"],
+            ["L", "K"],
+            ["M", "V"],
+            ["F", "W"],
+            ["Y", "H"],
+            ["R", "N"],
+            ["D", "E"],
+            ["Q", "C"],
+        ]
         metadata = pd.DataFrame(
             {
                 "confidence": [0.95 - (idx * 0.01) for idx in range(10)],
-                "prediction": [["A", "G"] for _ in range(10)],
+                "prediction": unique_predictions,
                 "retention_time": [float(idx) for idx in range(10)],
                 "spectrum_id": list(range(10)),
                 "experiment_name": ["exp_a"] * 10,

--- a/tests/calibration/features/test_retention_time.py
+++ b/tests/calibration/features/test_retention_time.py
@@ -43,6 +43,21 @@ class TestRetentionTimeFeature:
         assert retention_time_feature.columns == ["irt_error", "is_missing_irt_error"]
         assert retention_time_feature.dependencies == []
 
+    def test_check_valid_irt_prediction_treats_none_as_invalid(
+        self, retention_time_feature
+    ):
+        """Empty→None predictions must be iRT-invalid, not raise TypeError."""
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.95, 0.90, 0.85],
+                "prediction": [["A", "G"], None, ["U", "A"]],
+                "spectrum_id": [0, 1, 2],
+            }
+        )
+        dataset = CalibrationDataset(metadata=metadata, predictions=None)
+        is_valid = retention_time_feature.check_valid_irt_prediction(dataset)
+        assert is_valid.tolist() == [True, False, False]
+
     def test_initialization_parameters(self):
         """Test initialization with custom parameters."""
         feature = RetentionTimeFeature(

--- a/tests/calibration/test_calibrator.py
+++ b/tests/calibration/test_calibrator.py
@@ -4,6 +4,7 @@ import pickle
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.exceptions import ConvergenceWarning
 from winnow.calibration.calibrator import ProbabilityCalibrator
 from winnow.calibration.calibration_features import (
     CalibrationFeatures,
@@ -270,6 +271,52 @@ class TestProbabilityCalibrator:
         # Check that scaler and classifier were fitted (basic smoke test)
         assert hasattr(calibrator.scaler, "mean_")  # Scaler fitted
         assert hasattr(calibrator.classifier, "classes_")  # Classifier fitted
+
+    def test_fit_excludes_rows_without_valid_ground_truth_sequences(self):
+        """Unlabelled rows must not contribute to scaler or classifier fitting."""
+        n_labelled = 50
+        n_unlabelled = 10
+        np.random.seed(0)
+        metadata = pd.DataFrame(
+            {
+                "confidence": np.concatenate(
+                    [
+                        np.random.uniform(0.1, 0.99, n_labelled),
+                        np.random.uniform(0.1, 0.99, n_unlabelled),
+                    ]
+                ),
+                "sequence": [["A", "G"]] * n_labelled + [None] * n_unlabelled,
+                "valid_sequence": [True] * n_labelled + [False] * n_unlabelled,
+                "correct": np.concatenate(
+                    [np.random.choice([0, 1], n_labelled), np.zeros(n_unlabelled)]
+                ),
+            }
+        )
+        dataset = CalibrationDataset(
+            metadata=metadata,
+            predictions=[None] * len(metadata),
+        )
+        calibrator = ProbabilityCalibrator(seed=42, max_iter=10)
+        feature = MockCalibrationFeature("test_feature", ["test_col"])
+        calibrator.add_feature(feature)
+        with pytest.warns(ConvergenceWarning, match="Maximum iterations"):
+            calibrator.fit(dataset)
+
+        assert calibrator.scaler.n_samples_seen_ == n_labelled
+
+    def test_fit_raises_when_no_valid_ground_truth_sequences(self, calibrator):
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.9, 0.8],
+                "sequence": [None, []],
+                "valid_sequence": [False, False],
+                "correct": [0, 0],
+            }
+        )
+        dataset = CalibrationDataset(metadata=metadata, predictions=[None, None])
+        calibrator.add_feature(MockCalibrationFeature("test_feature", ["test_col"]))
+        with pytest.raises(ValueError, match="valid_sequence=True"):
+            calibrator.fit(dataset)
 
     def test_predict_after_fit(self, calibrator, labelled_dataset, sample_dataset):
         """Test prediction after fitting."""

--- a/tests/calibration/test_calibrator.py
+++ b/tests/calibration/test_calibrator.py
@@ -69,7 +69,11 @@ class TestProbabilityCalibrator:
     def sample_dataset(self):
         """Create a sample CalibrationDataset for testing."""
         metadata = pd.DataFrame(
-            {"confidence": [0.9, 0.8, 0.7, 0.6, 0.5], "other_col": [1, 2, 3, 4, 5]}
+            {
+                "confidence": [0.9, 0.8, 0.7, 0.6, 0.5],
+                "prediction": [["A"], ["G"], ["S"], ["V"], ["P"]],
+                "other_col": [1, 2, 3, 4, 5],
+            }
         )
         return CalibrationDataset(metadata=metadata, predictions=[None] * 5)
 
@@ -84,6 +88,7 @@ class TestProbabilityCalibrator:
         metadata = pd.DataFrame(
             {
                 "confidence": np.random.uniform(0.1, 0.99, n_samples),
+                "prediction": [["A", "G"]] * n_samples,
                 "correct": np.random.choice([0, 1], n_samples),
                 "feature1": np.random.uniform(1.0, 10.0, n_samples),
                 "feature2": np.random.uniform(0.1, 1.0, n_samples),
@@ -285,6 +290,7 @@ class TestProbabilityCalibrator:
                         np.random.uniform(0.1, 0.99, n_unlabelled),
                     ]
                 ),
+                "prediction": [["A", "G"]] * (n_labelled + n_unlabelled),
                 "sequence": [["A", "G"]] * n_labelled + [None] * n_unlabelled,
                 "valid_sequence": [True] * n_labelled + [False] * n_unlabelled,
                 "correct": np.concatenate(
@@ -304,11 +310,22 @@ class TestProbabilityCalibrator:
 
         assert calibrator.scaler.n_samples_seen_ == n_labelled
 
+    def test_fit_rejects_raw_proforma_string_ground_truth(self, labelled_dataset):
+        """Raw ProForma strings are rejected at CalibrationDataset construction."""
+        metadata = labelled_dataset.metadata.copy()
+        metadata["sequence"] = ["AG"] * len(metadata)
+        with pytest.raises(ValueError, match="raw strings"):
+            CalibrationDataset(
+                metadata=metadata,
+                predictions=labelled_dataset.predictions,
+            )
+
     def test_fit_raises_when_no_valid_ground_truth_sequences(self, calibrator):
         metadata = pd.DataFrame(
             {
                 "confidence": [0.9, 0.8],
-                "sequence": [None, []],
+                "prediction": [["A"], ["G"]],
+                "sequence": [None, None],
                 "valid_sequence": [False, False],
                 "correct": [0, 0],
             }
@@ -361,7 +378,7 @@ class TestProbabilityCalibrator:
 
     def test_empty_dataset_handling(self, calibrator):
         """Test handling of empty datasets."""
-        empty_metadata = pd.DataFrame({"confidence": []})  # Include confidence column
+        empty_metadata = pd.DataFrame({"confidence": [], "prediction": []})
         empty_dataset = CalibrationDataset(metadata=empty_metadata, predictions=[])
 
         feature = MockCalibrationFeature("test_feature")

--- a/tests/calibration/test_calibrator.py
+++ b/tests/calibration/test_calibrator.py
@@ -335,6 +335,21 @@ class TestProbabilityCalibrator:
         with pytest.raises(ValueError, match="valid_sequence=True"):
             calibrator.fit(dataset)
 
+    def test_fit_raises_when_correct_column_missing(self, calibrator):
+        """Missing finalised ``correct`` must raise before feature computation."""
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.9, 0.8],
+                "prediction": [["A", "G"], ["G", "A"]],
+                "sequence": [["A", "G"], ["G", "A"]],
+                "valid_sequence": [True, True],
+            }
+        )
+        dataset = CalibrationDataset(metadata=metadata, predictions=[None, None])
+        calibrator.add_feature(MockCalibrationFeature("test_feature", ["test_col"]))
+        with pytest.raises(ValueError, match="'correct' column"):
+            calibrator.fit(dataset)
+
     def test_predict_after_fit(self, calibrator, labelled_dataset, sample_dataset):
         """Test prediction after fitting."""
         feature = MockCalibrationFeature("test_feature", ["test_col"])

--- a/tests/calibration/test_diagnostics.py
+++ b/tests/calibration/test_diagnostics.py
@@ -72,6 +72,16 @@ class TestComputeCorrectFromSequence:
         correct = compute_correct_from_sequence(meta, RESIDUE_MASSES)
         assert correct.tolist() == expected
 
+    def test_absent_sequences_marked_incorrect(self) -> None:
+        meta = pd.DataFrame(
+            {
+                "sequence": [["A", "G"], None, []],
+                "prediction": [["A", "G"], ["A", "G"], ["A", "G"]],
+            }
+        )
+        correct = compute_correct_from_sequence(meta, RESIDUE_MASSES)
+        assert correct.tolist() == [True, False, False]
+
 
 class TestResolveDiagnosticsLabels:
     def test_precomputed_reads_column(self) -> None:
@@ -90,7 +100,6 @@ class TestResolveDiagnosticsLabels:
             {
                 "sequence": [["A"], ["A"]],
                 "prediction": [["A"], ["G"]],
-                "correct": [False, True],
             }
         )
         labels, column = resolve_diagnostics_labels(
@@ -101,6 +110,23 @@ class TestResolveDiagnosticsLabels:
         )
         assert column == SEQUENCE_LABEL_COLUMN
         assert labels.tolist() == [True, False]
+
+    def test_sequence_excludes_invalid_sequence_rows(self) -> None:
+        meta = pd.DataFrame(
+            {
+                "sequence": [["A"], None],
+                "prediction": [["A"], ["G"]],
+            }
+        )
+        labels, column = resolve_diagnostics_labels(
+            CalibrationDataset(metadata=meta),
+            "sequence",
+            None,
+            residue_masses=RESIDUE_MASSES,
+        )
+        assert column == SEQUENCE_LABEL_COLUMN
+        assert labels.tolist() == [True]
+        assert labels.index.tolist() == [0]
 
     def test_precomputed_missing_column_raises(self) -> None:
         with pytest.raises(ValueError, match="not found"):

--- a/tests/calibration/test_diagnostics.py
+++ b/tests/calibration/test_diagnostics.py
@@ -10,7 +10,6 @@ from winnow.calibration.diagnostics import (
     SEQUENCE_LABEL_COLUMN,
     DiagnosticArrays,
     TailSlice,
-    compute_correct_from_sequence,
     empirical_stece,
     filter_tail,
     fit_isotonic_calibration,
@@ -22,7 +21,13 @@ from winnow.calibration.diagnostics import (
 )
 from winnow.datasets.calibration_dataset import CalibrationDataset
 
-RESIDUE_MASSES = {"A": 71.037114, "G": 57.021464}
+
+def _token_prediction_frame(**columns: object) -> pd.DataFrame:
+    """Build metadata that satisfies CalibrationDataset peptide structure checks."""
+    frame = pd.DataFrame(columns)
+    if "prediction" not in frame.columns:
+        frame["prediction"] = [["A"]] * len(frame)
+    return frame
 
 
 class TestValidateLabelConfig:
@@ -53,76 +58,65 @@ class TestValidateLabelConfig:
         validate_label_config(label_source, label_column)
 
 
-class TestComputeCorrectFromSequence:
-    @pytest.mark.parametrize(
-        ("sequence", "prediction", "expected"),
-        [
-            ([["A", "G"], ["A"]], [["A", "G"], ["G"]], [True, False]),
-            (
-                [np.array(["A", "G"], dtype=object)],
-                [np.array(["A", "G"], dtype=object)],
-                [True],
-            ),
-        ],
-    )
-    def test_sequence_correctness(
-        self, sequence: object, prediction: object, expected: list[bool]
-    ) -> None:
-        meta = pd.DataFrame({"sequence": sequence, "prediction": prediction})
-        correct = compute_correct_from_sequence(meta, RESIDUE_MASSES)
-        assert correct.tolist() == expected
-
-    def test_absent_sequences_marked_incorrect(self) -> None:
-        meta = pd.DataFrame(
-            {
-                "sequence": [["A", "G"], None, []],
-                "prediction": [["A", "G"], ["A", "G"], ["A", "G"]],
-            }
-        )
-        correct = compute_correct_from_sequence(meta, RESIDUE_MASSES)
-        assert correct.tolist() == [True, False, False]
-
-
 class TestResolveDiagnosticsLabels:
     def test_precomputed_reads_column(self) -> None:
-        meta = pd.DataFrame({"proteome_hit": [True, False, True]})
+        meta = _token_prediction_frame(proteome_hit=[True, False, True])
         labels, column = resolve_diagnostics_labels(
             CalibrationDataset(metadata=meta),
             "precomputed",
             "proteome_hit",
-            residue_masses=RESIDUE_MASSES,
         )
         assert column == "proteome_hit"
         assert labels.tolist() == [True, False, True]
 
-    def test_sequence_uses_derived_correct_column(self) -> None:
-        meta = pd.DataFrame(
-            {
-                "sequence": [["A"], ["A"]],
-                "prediction": [["A"], ["G"]],
-            }
+    def test_sequence_uses_finalised_correct_column(self) -> None:
+        meta = _token_prediction_frame(
+            sequence=[["A"], ["A"]],
+            prediction=[["A"], ["G"]],
+            correct=[True, False],
+            valid_sequence=[True, True],
         )
         labels, column = resolve_diagnostics_labels(
             CalibrationDataset(metadata=meta),
             "sequence",
             None,
-            residue_masses=RESIDUE_MASSES,
         )
         assert column == SEQUENCE_LABEL_COLUMN
         assert labels.tolist() == [True, False]
 
-    def test_sequence_excludes_invalid_sequence_rows(self) -> None:
+    def test_sequence_rejects_raw_proforma_strings(self) -> None:
         meta = pd.DataFrame(
             {
-                "sequence": [["A"], None],
-                "prediction": [["A"], ["G"]],
+                "sequence": ["AG", "AG"],
+                "prediction": ["AG", "AA"],
             }
+        )
+        with pytest.raises(ValueError, match="raw strings"):
+            CalibrationDataset(metadata=meta)
+
+    def test_sequence_requires_finalised_correct(self) -> None:
+        meta = _token_prediction_frame(
+            sequence=[["A"], ["A"]],
+            prediction=[["A"], ["G"]],
+        )
+        with pytest.raises(ValueError, match="finalised labelled metadata"):
+            resolve_diagnostics_labels(
+                CalibrationDataset(metadata=meta),
+                "sequence",
+                None,
+            )
+
+    def test_sequence_excludes_invalid_sequence_rows(self) -> None:
+        meta = _token_prediction_frame(
+            sequence=[["A"], None],
+            prediction=[["A"], ["G"]],
+            correct=[True, False],
+            valid_sequence=[True, False],
         )
         labels, column = resolve_diagnostics_labels(
             CalibrationDataset(metadata=meta),
             "sequence",
             None,
-            residue_masses=RESIDUE_MASSES,
         )
         assert column == SEQUENCE_LABEL_COLUMN
         assert labels.tolist() == [True]
@@ -131,26 +125,22 @@ class TestResolveDiagnosticsLabels:
     def test_precomputed_missing_column_raises(self) -> None:
         with pytest.raises(ValueError, match="not found"):
             resolve_diagnostics_labels(
-                CalibrationDataset(metadata=pd.DataFrame({"confidence": [0.5]})),
+                CalibrationDataset(metadata=_token_prediction_frame(confidence=[0.5])),
                 "precomputed",
                 "proteome_hit",
-                residue_masses=RESIDUE_MASSES,
             )
 
     def test_precomputed_string_labels_raises(self) -> None:
         with pytest.raises(ValueError, match="must be a boolean or numeric series"):
             resolve_diagnostics_labels(
                 CalibrationDataset(
-                    metadata=pd.DataFrame(
-                        {
-                            "confidence": [0.5, 0.7, 0.6],
-                            "proteome_hit": ["True", "False", "True"],
-                        }
+                    metadata=_token_prediction_frame(
+                        confidence=[0.5, 0.7, 0.6],
+                        proteome_hit=["True", "False", "True"],
                     )
                 ),
                 "precomputed",
                 "proteome_hit",
-                residue_masses=RESIDUE_MASSES,
             )
 
 

--- a/tests/datasets/data_loaders/test_instanovo.py
+++ b/tests/datasets/data_loaders/test_instanovo.py
@@ -8,6 +8,16 @@ import polars as pl
 import pytest
 
 from winnow.datasets.data_loaders import InstaNovoDatasetLoader
+from winnow.datasets.data_loaders import utils
+
+
+def _finalize(loader, metadata, *, has_labels: bool = True):
+    return utils.finalize_peptide_metadata(
+        metadata,
+        loader.metrics,
+        has_labels=has_labels,
+        residue_remapping=loader.metrics.residue_set.residue_remapping,
+    )
 
 
 class TestInstaNovoDatasetLoader:
@@ -728,7 +738,7 @@ class TestInstaNovoDatasetLoader:
         result = loader._process_predictions(preds_df, ["spectrum_id"])
         assert result["prediction"].iloc[0] == ["P", "E", "P", "T", "I", "D", "E"]
 
-    def test_process_predictions_replaces_l_with_i_in_prediction_list(self, loader):
+    def test_finalize_replaces_l_with_i_in_prediction_list(self, loader):
         preds_df = pd.DataFrame(
             {
                 "spectrum_id": [1],
@@ -737,8 +747,9 @@ class TestInstaNovoDatasetLoader:
                 "log_probs": [-0.5],
             }
         )
-        result = loader._process_predictions(preds_df, ["spectrum_id"])
-        assert "L" not in result["prediction"].iloc[0]
+        processed = loader._process_predictions(preds_df, ["spectrum_id"])
+        finalized = _finalize(loader, processed, has_labels=False)
+        assert "L" not in finalized["prediction"].iloc[0]
 
     def test_process_predictions_replaces_l_with_i_in_prediction_untokenised(
         self, loader
@@ -773,22 +784,22 @@ class TestInstaNovoDatasetLoader:
         assert "precursor_mz" not in result.columns
 
     # ------------------------------------------------------------------
-    # _evaluate_predictions
+    # finalize_peptide_metadata (via loader metrics)
     # ------------------------------------------------------------------
 
     def test_evaluate_valid_prediction_true_for_list(self, loader):
         dataset = pd.DataFrame({"prediction": [["A", "G"]]})
-        result = loader._evaluate_predictions(dataset, has_labels=False)
+        result = _finalize(loader, dataset, has_labels=False)
         assert result["valid_prediction"].iloc[0]
 
-    def test_evaluate_valid_prediction_false_for_non_list(self, loader):
-        dataset = pd.DataFrame({"prediction": ["bad_string"]})
-        result = loader._evaluate_predictions(dataset, has_labels=False)
+    def test_evaluate_valid_prediction_false_for_empty_list(self, loader):
+        dataset = pd.DataFrame({"prediction": [[]]})
+        result = _finalize(loader, dataset, has_labels=False)
         assert not result["valid_prediction"].iloc[0]
 
     def test_evaluate_no_label_columns_when_no_labels(self, loader):
         dataset = pd.DataFrame({"prediction": [["A", "G"]]})
-        result = loader._evaluate_predictions(dataset, has_labels=False)
+        result = _finalize(loader, dataset, has_labels=False)
         assert "correct" not in result.columns
         assert "valid_sequence" not in result.columns
         assert "num_matches" not in result.columns
@@ -796,34 +807,47 @@ class TestInstaNovoDatasetLoader:
     def test_evaluate_correct_flag_true_on_full_match(self, loader):
         seq = ["P", "E", "P"]
         dataset = pd.DataFrame({"sequence": [seq], "prediction": [seq]})
-        result = loader._evaluate_predictions(dataset, has_labels=True)
+        result = _finalize(loader, dataset, has_labels=True)
         assert result["correct"].iloc[0]
 
     def test_evaluate_correct_flag_false_on_different_sequence(self, loader):
         dataset = pd.DataFrame(
             {"sequence": [["P", "E", "P"]], "prediction": [["A", "E", "P"]]}
         )
-        result = loader._evaluate_predictions(dataset, has_labels=True)
+        result = _finalize(loader, dataset, has_labels=True)
         assert not result["correct"].iloc[0]
 
     def test_evaluate_correct_flag_false_on_length_mismatch(self, loader):
         dataset = pd.DataFrame(
             {"sequence": [["P", "E", "P"]], "prediction": [["P", "E"]]}
         )
-        result = loader._evaluate_predictions(dataset, has_labels=True)
+        result = _finalize(loader, dataset, has_labels=True)
         assert not result["correct"].iloc[0]
 
     def test_evaluate_num_matches_full_match(self, loader):
         seq = ["P", "E", "P"]
         dataset = pd.DataFrame({"sequence": [seq], "prediction": [seq]})
-        result = loader._evaluate_predictions(dataset, has_labels=True)
+        result = _finalize(loader, dataset, has_labels=True)
         assert result["num_matches"].iloc[0] == len(seq)
 
     def test_evaluate_num_matches_zero_on_invalid_prediction(self, loader):
-        """Non-list prediction should give 0 matches."""
         dataset = pd.DataFrame({"sequence": [["P", "E", "P"]], "prediction": [None]})
-        result = loader._evaluate_predictions(dataset, has_labels=True)
+        result = _finalize(loader, dataset, has_labels=True)
         assert result["num_matches"].iloc[0] == 0
+
+    def test_evaluate_imputes_valid_sequence_and_correct_for_partial_labels(
+        self, loader
+    ):
+        dataset = pd.DataFrame(
+            {
+                "sequence": [["P", "E", "P"], None, []],
+                "prediction": [["P", "E", "P"], ["A", "G"], ["A", "G"]],
+            }
+        )
+        result = _finalize(loader, dataset, has_labels=True)
+        assert result["valid_sequence"].tolist() == [True, False, False]
+        assert result["correct"].tolist() == [True, False, False]
+        assert result["num_matches"].tolist() == [3, 0, 0]
 
     # ------------------------------------------------------------------
     # load() – error handling

--- a/tests/datasets/data_loaders/test_instanovo.py
+++ b/tests/datasets/data_loaders/test_instanovo.py
@@ -543,7 +543,7 @@ class TestInstaNovoDatasetLoader:
         assert hasattr(beams[0][0], "sequence_log_probability")
 
     def test_process_beams_replaces_l_with_i_in_sequences(self, loader):
-        """L amino acid must be replaced with I before tokenization."""
+        """L amino acid must be replaced with I at token level after split."""
         beam_df = pl.DataFrame(
             {
                 "predictions_beam_0": ["PEPTLDE"],
@@ -751,19 +751,18 @@ class TestInstaNovoDatasetLoader:
         finalized = _finalize(loader, processed, has_labels=False)
         assert "L" not in finalized["prediction"].iloc[0]
 
-    def test_process_predictions_replaces_l_with_i_in_prediction_untokenised(
-        self, loader
-    ):
+    def test_process_predictions_preserves_l_in_prediction_untokenised(self, loader):
+        """Untokenised strings keep source L; leucine remap is token-level only."""
         preds_df = pd.DataFrame(
             {
                 "spectrum_id": [1],
                 "predictions": ["PEPTLDE"],
-                "predictions_tokenised": ["P, E, P, T, I, D, E"],
+                "predictions_tokenised": ["P, E, P, T, L, D, E"],
                 "log_probs": [-0.5],
             }
         )
         result = loader._process_predictions(preds_df, ["spectrum_id"])
-        assert "L" not in result["prediction_untokenised"].iloc[0]
+        assert result["prediction_untokenised"].iloc[0] == "PEPTLDE"
 
     def test_process_predictions_drops_duplicate_input_columns(self, loader):
         """Columns present in input spectrum data (except spectrum_id) must be dropped."""

--- a/tests/datasets/data_loaders/test_instanovo.py
+++ b/tests/datasets/data_loaders/test_instanovo.py
@@ -8,11 +8,11 @@ import polars as pl
 import pytest
 
 from winnow.datasets.data_loaders import InstaNovoDatasetLoader
-from winnow.datasets.data_loaders import utils
+from winnow.datasets.data_loaders import utils as data_utils
 
 
 def _finalize(loader, metadata, *, has_labels: bool = True):
-    return utils.finalize_peptide_metadata(
+    return data_utils.finalize_peptide_metadata(
         metadata,
         loader.metrics,
         has_labels=has_labels,

--- a/tests/datasets/data_loaders/test_instanovo.py
+++ b/tests/datasets/data_loaders/test_instanovo.py
@@ -571,6 +571,67 @@ class TestInstaNovoDatasetLoader:
         beams = loader._process_beams(beam_df)
         assert beams[0] is None
 
+    @pytest.mark.parametrize(
+        "falsy_sequence",
+        ["", None],
+        ids=["empty_string", "none"],
+    )
+    def test_process_beams_skips_falsy_runner_up(self, loader, falsy_sequence):
+        """Blank/missing runner-ups are dropped, keeping only the top sequence."""
+        beam_df = pl.DataFrame(
+            {
+                "predictions_beam_0": ["PEPTIDE"],
+                "predictions_log_probability_beam_0": [-0.1],
+                "predictions_token_log_probabilities_0": [
+                    "[-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7]"
+                ],
+                "predictions_beam_1": [falsy_sequence],
+                "predictions_log_probability_beam_1": [-1.2],
+                "predictions_token_log_probabilities_1": ["[-0.5]"],
+            }
+        )
+        beams = loader._process_beams(beam_df)
+        assert beams[0] is not None
+        assert len(beams[0]) == 1
+        assert beams[0][0].sequence == list("PEPTIDE")
+
+    def test_process_beams_skips_falsy_and_compacts_beam(self, loader):
+        """A falsy middle beam is dropped so the next valid candidate becomes beam[1]."""
+        beam_df = pl.DataFrame(
+            {
+                "predictions_beam_0": ["PEPTIDE"],
+                "predictions_log_probability_beam_0": [-0.1],
+                "predictions_token_log_probabilities_0": [
+                    "[-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7]"
+                ],
+                "predictions_beam_1": [""],
+                "predictions_log_probability_beam_1": [-0.5],
+                "predictions_token_log_probabilities_1": ["[-0.5]"],
+                "predictions_beam_2": ["AC"],
+                "predictions_log_probability_beam_2": [-1.0],
+                "predictions_token_log_probabilities_2": ["[-0.3, -0.4]"],
+            }
+        )
+        beams = loader._process_beams(beam_df)
+        assert beams[0] is not None
+        assert len(beams[0]) == 2
+        assert beams[0][0].sequence == list("PEPTIDE")
+        assert beams[0][1].sequence == ["A", "C"]
+
+    def test_process_beams_all_falsy_sequences_returns_none(self, loader):
+        beam_df = pl.DataFrame(
+            {
+                "predictions_beam_0": [""],
+                "predictions_log_probability_beam_0": [-0.1],
+                "predictions_token_log_probabilities_0": ["[-0.1]"],
+                "predictions_beam_1": [None],
+                "predictions_log_probability_beam_1": [-1.2],
+                "predictions_token_log_probabilities_1": ["[-0.5]"],
+            }
+        )
+        beams = loader._process_beams(beam_df)
+        assert beams[0] is None
+
     def test_process_beams_parses_string_token_log_probabilities(self, loader):
         """token_log_probabilities stored as a string should be parsed to a list."""
         token_str = "[-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7]"

--- a/tests/datasets/data_loaders/test_mztab.py
+++ b/tests/datasets/data_loaders/test_mztab.py
@@ -11,6 +11,25 @@ from winnow.datasets.data_loaders import utils
 EXPERIMENT_NAME = "test"
 
 
+def _finalize(loader, metadata, *, has_labels: bool = True):
+    """Run shared peptide finalization with loader metrics/remapping."""
+    return utils.finalize_peptide_metadata(
+        metadata,
+        loader.metrics,
+        has_labels=has_labels,
+        residue_remapping=loader.metrics.residue_set.residue_remapping,
+    )
+
+
+def _normalize_peptide(loader, value: object) -> list[str] | None:
+    """Normalize a peptide cell using loader metrics (string or token list)."""
+    return utils.normalize_peptide_cell(
+        value,
+        loader.metrics,
+        residue_remapping=loader.metrics.residue_set.residue_remapping,
+    )
+
+
 class TestMZTabDatasetLoader:
     """Unit tests for MZTabDatasetLoader."""
 
@@ -108,46 +127,36 @@ class TestMZTabDatasetLoader:
         ]
 
     # ------------------------------------------------------------------
-    # _remap_tokens – notation remapping
+    # Token remapping via utils.normalize_peptide_cell
     # ------------------------------------------------------------------
 
     def test_remap_tokens_residue_modifications(self, mztab_loader):
         """Test token-level remapping of residue modifications."""
-        # Test mass-based notation
         tokens = ["M+15.995", "P", "E", "P", "T", "I", "D", "E"]
         expected = ["M[UNIMOD:35]", "P", "E", "P", "T", "I", "D", "E"]
-        assert mztab_loader._remap_tokens(tokens) == expected
+        assert _normalize_peptide(mztab_loader, tokens) == expected
 
-        # Test named notation
         tokens = ["M[Oxidation]", "P", "E", "P", "T", "I", "D", "E"]
-        expected = ["M[UNIMOD:35]", "P", "E", "P", "T", "I", "D", "E"]
-        assert mztab_loader._remap_tokens(tokens) == expected
+        assert _normalize_peptide(mztab_loader, tokens) == expected
 
     def test_remap_tokens_terminal_modifications(self, mztab_loader):
-        """Test token-level remapping of N-terminal modifications.
-
-        Note: Hyphens are stripped by the tokenizer, so we only need to
-        match the modification token without the hyphen.
-        """
-        # Test mass-based notation (tokenizer captures "+42.011" as standalone token)
+        """Test token-level remapping of N-terminal modifications."""
         tokens = ["+42.011", "P", "E", "P", "T", "I", "D", "E"]
         expected = ["[UNIMOD:1]", "P", "E", "P", "T", "I", "D", "E"]
-        assert mztab_loader._remap_tokens(tokens) == expected
+        assert _normalize_peptide(mztab_loader, tokens) == expected
 
-        # Test named notation (tokenizer captures "[Acetyl]" without the hyphen)
         tokens = ["[Acetyl]", "P", "E", "P", "T", "I", "D", "E"]
-        expected = ["[UNIMOD:1]", "P", "E", "P", "T", "I", "D", "E"]
-        assert mztab_loader._remap_tokens(tokens) == expected
+        assert _normalize_peptide(mztab_loader, tokens) == expected
 
     def test_remap_tokens_no_modifications(self, mztab_loader):
         """Test that unmodified tokens pass through unchanged."""
         tokens = ["P", "E", "P", "T", "I", "D", "E"]
-        assert mztab_loader._remap_tokens(tokens) == tokens
+        assert _normalize_peptide(mztab_loader, tokens) == tokens
 
     def test_remap_tokens_already_unimod(self, mztab_loader):
         """Test that tokens already in Proforma format are unchanged."""
         tokens = ["M[UNIMOD:35]", "P", "E", "P", "T", "I", "D", "E"]
-        assert mztab_loader._remap_tokens(tokens) == tokens
+        assert _normalize_peptide(mztab_loader, tokens) == tokens
 
     # ------------------------------------------------------------------
     # Token remapping integration – Casanovo ↔ invalid residue detection
@@ -196,9 +205,7 @@ class TestMZTabDatasetLoader:
         for casanovo_seq, expected_token in casanovo_sequences:
             # Tokenize first (regex strips hyphens from N-terminal mods)
             tokens = loader.metrics._split_peptide(casanovo_seq)
-
-            # Then remap tokens
-            remapped_tokens = loader._remap_tokens(tokens)
+            remapped_tokens = _normalize_peptide(loader, tokens)
 
             # Verify that the remapped tokens contain the expected invalid token
             assert expected_token in remapped_tokens, (
@@ -421,10 +428,9 @@ class TestMZTabDatasetLoader:
         )
         assert result["prediction_untokenised"][0] == "PEPTC[Carbamidomethyl]DE"
 
-    def test_tokenize_replaces_leucine_at_token_level(self, loader):
-        df = pl.DataFrame({"seq": ["PEPTLDE"]})
-        result = loader._tokenize(df, "seq", "tokens")
-        tokens = result["tokens"][0].to_list()
+    def test_normalize_replaces_leucine_at_token_level(self, loader):
+        tokens = _normalize_peptide(loader, "PEPTLDE")
+        assert tokens is not None
         assert "L" not in tokens
         assert "I" in tokens
 
@@ -475,44 +481,34 @@ class TestMZTabDatasetLoader:
         assert idx1_rows["confidence"][0] > idx1_rows["confidence"][1]
 
     # ------------------------------------------------------------------
-    # _tokenize
+    # normalize_peptide_cell (string inputs)
     # ------------------------------------------------------------------
 
-    def test_tokenize_splits_simple_sequence(self, loader):
-        df = pl.DataFrame({"seq": ["PEPTIDE"]})
-        result = loader._tokenize(df, "seq", "tokens")
-        tokens = result["tokens"][0].to_list()
+    def test_normalize_splits_simple_sequence(self, loader):
+        tokens = _normalize_peptide(loader, "PEPTIDE")
         assert tokens == ["P", "E", "P", "T", "I", "D", "E"]
 
-    def test_tokenize_strips_hyphen_from_nterm_modification(self, loader):
-        """[Acetyl]-PEPTIDE: hyphen should be stripped by tokenizer, then remapped."""
-        df = pl.DataFrame({"seq": ["[Acetyl]-PEPTIDE"]})
-        result = loader._tokenize(df, "seq", "tokens")
-        tokens = result["tokens"][0].to_list()
+    def test_normalize_strips_hyphen_from_nterm_modification(self, loader):
+        tokens = _normalize_peptide(loader, "[Acetyl]-PEPTIDE")
+        assert tokens is not None
         assert "[UNIMOD:1]" in tokens
         assert "-" not in tokens
 
-    def test_tokenize_remaps_modification_tokens(self, loader):
-        """M[Oxidation] should be remapped to M[UNIMOD:35] after tokenization."""
-        df = pl.DataFrame({"seq": ["M[Oxidation]PEPTIDE"]})
-        result = loader._tokenize(df, "seq", "tokens")
-        tokens = result["tokens"][0].to_list()
+    def test_normalize_remaps_modification_tokens(self, loader):
+        tokens = _normalize_peptide(loader, "M[Oxidation]PEPTIDE")
+        assert tokens is not None
         assert "M[UNIMOD:35]" in tokens
         assert "M[Oxidation]" not in tokens
 
-    def test_tokenize_remaps_carbamidomethyl_without_corrupting_name(self, loader):
-        df = pl.DataFrame({"seq": ["GEEHC[Carbamidomethyl]GHLLQAHK"]})
-        result = loader._tokenize(df, "seq", "tokens")
-        tokens = result["tokens"][0].to_list()
+    def test_normalize_remaps_carbamidomethyl_without_corrupting_name(self, loader):
+        tokens = _normalize_peptide(loader, "GEEHC[Carbamidomethyl]GHLLQAHK")
+        assert tokens is not None
         assert "C[UNIMOD:4]" in tokens
         assert "L" not in tokens
         assert tokens.count("I") == 2
 
-    def test_tokenize_unmodified_sequence_passes_through(self, loader):
-        df = pl.DataFrame({"seq": ["ACGM"]})
-        result = loader._tokenize(df, "seq", "tokens")
-        tokens = result["tokens"][0].to_list()
-        assert tokens == ["A", "C", "G", "M"]
+    def test_normalize_unmodified_sequence_passes_through(self, loader):
+        assert _normalize_peptide(loader, "ACGM") == ["A", "C", "G", "M"]
 
     # ------------------------------------------------------------------
     # _get_top_predictions
@@ -760,9 +756,10 @@ class TestMZTabDatasetLoader:
         processed = db_loader._process_predictions(
             raw, [], is_casanovo=False, experiment_name=EXPERIMENT_NAME
         )
-        processed = db_loader._tokenize(
-            processed, "prediction_untokenised", "prediction"
+        processed = processed.with_columns(
+            pl.col("prediction_untokenised").alias("prediction")
         )
+        processed = _finalize(db_loader, processed, has_labels=False)
         top = db_loader._get_top_predictions(processed, is_casanovo=False)
         merged = db_loader._merge_data(spectrum, top)
 
@@ -794,3 +791,88 @@ class TestMZTabDatasetLoader:
             db_loader._process_predictions(
                 df, [], is_casanovo=False, experiment_name=EXPERIMENT_NAME
             )
+
+
+class TestMZTabEvaluatePredictions:
+    """Tests for finalize_peptide_metadata on mzTab-style frames (parity with InstaNovo)."""
+
+    @pytest.fixture()
+    def loader(self, full_residue_masses, standard_remapping):
+        return MZTabDatasetLoader(
+            residue_masses=full_residue_masses,
+            residue_remapping=standard_remapping,
+        )
+
+    def test_evaluate_valid_prediction_true_for_list(self, loader):
+        metadata = pl.DataFrame({"prediction": [["A", "G"]]})
+        result = _finalize(loader, metadata, has_labels=False)
+        assert result["valid_prediction"][0]
+
+    def test_evaluate_valid_prediction_false_for_empty(self, loader):
+        metadata = pl.DataFrame({"prediction": [[]]})
+        result = _finalize(loader, metadata, has_labels=False)
+        assert not result["valid_prediction"][0]
+
+    def test_evaluate_no_label_columns_when_no_labels(self, loader):
+        metadata = pl.DataFrame({"prediction": [["A", "G"]]})
+        result = _finalize(loader, metadata, has_labels=False)
+        assert "correct" not in result.columns
+        assert "valid_sequence" not in result.columns
+        assert "num_matches" not in result.columns
+
+    def test_evaluate_correct_flag_true_on_full_match(self, loader):
+        seq = ["P", "E", "P"]
+        metadata = pl.DataFrame({"sequence": [seq], "prediction": [seq]})
+        result = _finalize(loader, metadata, has_labels=True)
+        assert result["correct"][0]
+
+    def test_evaluate_correct_flag_false_on_different_sequence(self, loader):
+        metadata = pl.DataFrame(
+            {"sequence": [["P", "E", "P"]], "prediction": [["A", "E", "P"]]}
+        )
+        result = _finalize(loader, metadata, has_labels=True)
+        assert not result["correct"][0]
+
+    def test_evaluate_correct_flag_false_on_length_mismatch(self, loader):
+        metadata = pl.DataFrame(
+            {"sequence": [["P", "E", "P"]], "prediction": [["P", "E"]]}
+        )
+        result = _finalize(loader, metadata, has_labels=True)
+        assert not result["correct"][0]
+
+    def test_evaluate_num_matches_full_match(self, loader):
+        seq = ["P", "E", "P"]
+        metadata = pl.DataFrame({"sequence": [seq], "prediction": [seq]})
+        result = _finalize(loader, metadata, has_labels=True)
+        assert result["num_matches"][0] == len(seq)
+
+    def test_evaluate_num_matches_zero_on_invalid_prediction(self, loader):
+        metadata = pl.DataFrame({"sequence": [["P", "E", "P"]], "prediction": [None]})
+        result = _finalize(loader, metadata, has_labels=True)
+        assert result["num_matches"][0] == 0
+
+    def test_evaluate_empty_sequence_list_sets_valid_sequence_false(self, loader):
+        metadata = pl.DataFrame({"sequence": [[]], "prediction": [["P", "E", "P"]]})
+        result = _finalize(loader, metadata, has_labels=True)
+        assert not result["valid_sequence"][0]
+        assert result["num_matches"][0] == 0
+        assert not result["correct"][0]
+
+    def test_evaluate_empty_prediction_list_sets_valid_prediction_false(self, loader):
+        metadata = pl.DataFrame({"sequence": [["P", "E", "P"]], "prediction": [[]]})
+        result = _finalize(loader, metadata, has_labels=True)
+        assert not result["valid_prediction"][0]
+
+    def test_evaluate_imputes_valid_sequence_and_correct_for_partial_labels(
+        self, loader
+    ):
+        metadata = pl.DataFrame(
+            {
+                "sequence": [["P", "E", "P"], None, []],
+                "prediction": [["P", "E", "P"], ["A", "G"], ["A", "G"]],
+            }
+        )
+        result = _finalize(loader, metadata, has_labels=True)
+        assert result["valid_sequence"].to_list() == [True, False, False]
+        assert result["correct"].to_list() == [True, False, False]
+        assert result["num_matches"].to_list() == [3, 0, 0]

--- a/tests/datasets/data_loaders/test_mztab.py
+++ b/tests/datasets/data_loaders/test_mztab.py
@@ -631,6 +631,66 @@ class TestMZTabDatasetLoader:
             [np.log(0.4), np.log(0.5), np.log(0.6)]
         )
 
+    @pytest.mark.parametrize(
+        "falsy_prediction",
+        [None, []],
+        ids=["none", "empty_list"],
+    )
+    def test_create_casanovo_beam_predictions_skips_falsy_runner_up(
+        self, loader, falsy_prediction
+    ):
+        """Blank/missing runner-ups are dropped from beams, not stored as None."""
+        df = pl.DataFrame(
+            {
+                "index": pl.Series([0, 0], dtype=pl.Int64),
+                "confidence": [0.9, 0.2],
+                "prediction": pl.Series(
+                    [["P", "E", "P"], falsy_prediction], dtype=pl.List(pl.Utf8)
+                ),
+                "token_scores": pl.Series(
+                    [[0.9, 0.8, 0.7], None], dtype=pl.List(pl.Float64)
+                ),
+            }
+        )
+        result = loader._create_casanovo_beam_predictions(df, [0])
+        assert result[0] is not None
+        assert len(result[0]) == 1
+        assert result[0][0].sequence == ["P", "E", "P"]
+
+    def test_create_casanovo_beam_predictions_skips_falsy_and_compacts_beam(
+        self, loader
+    ):
+        """A falsy middle rank is dropped so the next valid candidate becomes beam[1]."""
+        df = pl.DataFrame(
+            {
+                "index": pl.Series([0, 0, 0], dtype=pl.Int64),
+                "confidence": [0.9, 0.5, 0.2],
+                "prediction": pl.Series(
+                    [["P", "E", "P"], None, ["A", "C"]], dtype=pl.List(pl.Utf8)
+                ),
+                "token_scores": pl.Series(
+                    [None, None, None], dtype=pl.List(pl.Float64)
+                ),
+            }
+        )
+        result = loader._create_casanovo_beam_predictions(df, [0])
+        assert result[0] is not None
+        assert len(result[0]) == 2
+        assert result[0][0].sequence == ["P", "E", "P"]
+        assert result[0][1].sequence == ["A", "C"]
+
+    def test_create_casanovo_beam_predictions_all_falsy_returns_none(self, loader):
+        df = pl.DataFrame(
+            {
+                "index": pl.Series([0, 0], dtype=pl.Int64),
+                "confidence": [0.9, 0.2],
+                "prediction": pl.Series([None, []], dtype=pl.List(pl.Utf8)),
+                "token_scores": pl.Series([None, None], dtype=pl.List(pl.Float64)),
+            }
+        )
+        result = loader._create_casanovo_beam_predictions(df, [0])
+        assert result[0] is None
+
     # ------------------------------------------------------------------
     # load() – validation
     # ------------------------------------------------------------------

--- a/tests/datasets/data_loaders/test_mztab.py
+++ b/tests/datasets/data_loaders/test_mztab.py
@@ -5,7 +5,7 @@ import polars as pl
 import pytest
 
 from winnow.datasets.data_loaders import MZTabDatasetLoader
-from winnow.datasets.data_loaders import utils
+from winnow.datasets.data_loaders import utils as data_utils
 
 
 EXPERIMENT_NAME = "test"
@@ -13,7 +13,7 @@ EXPERIMENT_NAME = "test"
 
 def _finalize(loader, metadata, *, has_labels: bool = True):
     """Run shared peptide finalization with loader metrics/remapping."""
-    return utils.finalize_peptide_metadata(
+    return data_utils.finalize_peptide_metadata(
         metadata,
         loader.metrics,
         has_labels=has_labels,
@@ -23,7 +23,7 @@ def _finalize(loader, metadata, *, has_labels: bool = True):
 
 def _normalize_peptide(loader, value: object) -> list[str] | None:
     """Normalize a peptide cell using loader metrics (string or token list)."""
-    return utils.normalize_peptide_cell(
+    return data_utils.normalize_peptide_cell(
         value,
         loader.metrics,
         residue_remapping=loader.metrics.residue_set.residue_remapping,
@@ -127,7 +127,7 @@ class TestMZTabDatasetLoader:
         ]
 
     # ------------------------------------------------------------------
-    # Token remapping via utils.normalize_peptide_cell
+    # Token remapping via data_utils.normalize_peptide_cell
     # ------------------------------------------------------------------
 
     def test_remap_tokens_residue_modifications(self, mztab_loader):
@@ -353,7 +353,7 @@ class TestMZTabDatasetLoader:
 
     def test_add_row_order_spectrum_ids_assigns_sequential_ids(self):
         df = pl.DataFrame({"charge": [2, 2]})
-        result = utils.add_row_order_spectrum_ids(df, "spec")
+        result = data_utils.add_row_order_spectrum_ids(df, "spec")
         assert result["experiment_name"].to_list() == ["spec", "spec"]
         assert result["spectrum_id"].to_list() == ["spec:0", "spec:1"]
 
@@ -744,7 +744,7 @@ class TestMZTabDatasetLoader:
                 "search_engine_score[1]": [0.3, 0.9],
             }
         )
-        spectrum = utils.add_row_order_spectrum_ids(
+        spectrum = data_utils.add_row_order_spectrum_ids(
             pl.DataFrame(
                 {
                     "charge": [2, 2],

--- a/tests/datasets/data_loaders/test_utils.py
+++ b/tests/datasets/data_loaders/test_utils.py
@@ -1,0 +1,285 @@
+"""Tests for shared dataset loader utilities."""
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+from instanovo.utils.metrics import Metrics
+from instanovo.utils.residues import ResidueSet
+
+from winnow.datasets.data_loaders import utils
+
+RESIDUE_MASSES = {
+    "A": 71.037114,
+    "G": 57.021464,
+    "P": 97.052764,
+    "E": 129.042593,
+    "L": 113.084064,
+}
+REMAPPING = {"M[Oxidation]": "M[UniMod:35]"}
+
+
+@pytest.fixture()
+def metrics() -> Metrics:
+    return Metrics(
+        residue_set=ResidueSet(
+            residue_masses=RESIDUE_MASSES,
+            residue_remapping=REMAPPING,
+        )
+    )
+
+
+class TestHasGroundTruthSequenceLabels:
+    """Tests for ground-truth sequence detection at load time."""
+
+    def test_true_when_sequence_has_content(self):
+        df = pl.DataFrame({"sequence": ["PEPTIDE"], "charge": [2]})
+        assert utils.has_ground_truth_sequence_labels(df) is True
+
+    def test_true_when_sequence_has_at_least_one_non_empty_value(self):
+        df = pl.DataFrame({"sequence": ["PEPTIDE", "", None], "charge": [2, 3, 4]})
+        assert utils.has_ground_truth_sequence_labels(df) is True
+        assert len(df) == 3
+
+    def test_false_when_sequence_column_missing(self):
+        df = pl.DataFrame({"charge": [2]})
+        assert utils.has_ground_truth_sequence_labels(df) is False
+
+    def test_false_when_sequence_column_all_empty(self):
+        df = pl.DataFrame({"sequence": ["", "   ", None], "charge": [2, 3, 4]})
+        assert utils.has_ground_truth_sequence_labels(df) is False
+
+    def test_load_spectrum_data_drops_empty_sequence_column(self, tmp_path):
+        df = pl.DataFrame({"sequence": ["", None], "charge": [2, 3]})
+        path = tmp_path / "empty_labels.parquet"
+        df.write_parquet(path)
+
+        loaded, has_labels = utils.load_spectrum_data(path)
+
+        assert has_labels is False
+        assert "sequence" not in loaded.columns
+
+
+class TestIsValidPeptideTokens:
+    """Validity checks apply identically to sequence and prediction cells."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            ["A", "G"],
+            ("A", "G"),
+            np.array(["A", "G"], dtype=object),
+            pl.Series(["A", "G"]),
+        ],
+    )
+    def test_valid_non_empty_containers(self, value: object) -> None:
+        assert utils.is_valid_peptide_tokens(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            [],
+            np.array([]),
+            pl.Series([]),
+            "",
+            "PEPTIDE",
+            float("nan"),
+            pd.NA,
+        ],
+    )
+    def test_invalid_values(self, value: object) -> None:
+        assert utils.is_valid_peptide_tokens(value) is False
+
+    def test_as_token_list_matches_validity(self):
+        assert utils.is_valid_peptide_tokens(["A", "G"]) == (
+            utils.as_token_list(["A", "G"]) is not None
+        )
+
+
+class TestNormalizePeptideCell:
+    def test_string_splits_and_remaps(self, metrics: Metrics) -> None:
+        tokens = utils.normalize_peptide_cell(
+            "AG",
+            metrics,
+            residue_remapping=REMAPPING,
+        )
+        assert tokens == ["A", "G"]
+
+    def test_leucine_mapped_at_token_level(self, metrics: Metrics) -> None:
+        tokens = utils.normalize_peptide_cell(
+            ["A", "L"],
+            metrics,
+            residue_remapping=REMAPPING,
+        )
+        assert tokens == ["A", "I"]
+
+    def test_modification_remapping_on_list_input(self, metrics: Metrics) -> None:
+        tokens = utils.normalize_peptide_cell(
+            ["M[Oxidation]", "A"],
+            metrics,
+            residue_remapping=REMAPPING,
+        )
+        assert tokens == ["M[UniMod:35]", "A"]
+
+    def test_require_label_false_for_absent(self, metrics: Metrics) -> None:
+        assert (
+            utils.normalize_peptide_cell(
+                None,
+                metrics,
+                residue_remapping=REMAPPING,
+                require_label=True,
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            np.array(["P", "E"], dtype=object),
+            pl.Series(["P", "E"]),
+        ],
+    )
+    def test_accepts_ndarray_and_polars_series(
+        self, metrics: Metrics, value: object
+    ) -> None:
+        tokens = utils.normalize_peptide_cell(
+            value,
+            metrics,
+            residue_remapping=REMAPPING,
+        )
+        assert tokens == ["P", "E"]
+
+
+class TestLabelledTrainingMask:
+    def test_imputes_valid_sequence_from_sequence(self):
+        metadata = pd.DataFrame({"sequence": [["A"], None, ["B"]]})
+        assert utils.labelled_training_mask(metadata).tolist() == [True, False, True]
+        assert metadata["valid_sequence"].tolist() == [True, False, True]
+
+    def test_uses_existing_valid_sequence_column(self):
+        metadata = pd.DataFrame(
+            {"valid_sequence": [True, False, True], "sequence": [["A"], None, ["B"]]}
+        )
+        assert utils.labelled_training_mask(metadata).tolist() == [True, False, True]
+
+    def test_require_labelled_rows_raises_when_empty(self):
+        metadata = pd.DataFrame(
+            {
+                "sequence": [None],
+                "valid_sequence": [False],
+            }
+        )
+        with pytest.raises(ValueError, match="valid_sequence=True"):
+            utils.require_labelled_rows(metadata, context="Test context")
+
+
+class TestRowEvaluation:
+    def test_row_num_matches_and_correct(self, metrics: Metrics) -> None:
+        assert (
+            utils.row_num_matches(
+                ["A", "G"],
+                ["A", "G"],
+                metrics,
+                sequence_valid=True,
+                prediction_valid=True,
+            )
+            == 2
+        )
+        assert (
+            utils.row_num_matches(
+                ["A", "G"],
+                ["A", "G"],
+                metrics,
+                sequence_valid=False,
+                prediction_valid=True,
+            )
+            == 0
+        )
+        assert utils.row_is_correct(
+            2, ["A", "G"], ["A", "G"], sequence_valid=True, prediction_valid=True
+        )
+        assert not utils.row_is_correct(
+            1, ["A", "G"], ["A", "G"], sequence_valid=True, prediction_valid=True
+        )
+
+
+class TestFinalizePeptideMetadata:
+    @pytest.fixture()
+    def labelled_fixture(self) -> dict[str, list]:
+        return {
+            "sequence": [["P", "E"], None],
+            "prediction": [["P", "E"], ["P", "E"]],
+        }
+
+    def test_pandas_frame(self, metrics: Metrics, labelled_fixture: dict) -> None:
+        metadata = pd.DataFrame(labelled_fixture)
+        utils.finalize_peptide_metadata(
+            metadata,
+            metrics,
+            has_labels=True,
+            residue_remapping=REMAPPING,
+        )
+        assert metadata["valid_sequence"].tolist() == [True, False]
+        assert metadata["valid_prediction"].tolist() == [True, True]
+        assert metadata["correct"].tolist() == [True, False]
+        assert metadata["num_matches"].tolist() == [2, 0]
+        assert all(isinstance(v, list) for v in metadata["prediction"])
+
+    def test_polars_frame(self, metrics: Metrics, labelled_fixture: dict) -> None:
+        metadata = pl.DataFrame(labelled_fixture)
+        result = utils.finalize_peptide_metadata(
+            metadata,
+            metrics,
+            has_labels=True,
+            residue_remapping=REMAPPING,
+        )
+        assert isinstance(result, pl.DataFrame)
+        assert result["valid_sequence"].to_list() == [True, False]
+        assert result["valid_prediction"].to_list() == [True, True]
+        assert result["correct"].to_list() == [True, False]
+        assert result["num_matches"].to_list() == [2, 0]
+
+    def test_pandas_with_ndarray_cells(self, metrics: Metrics) -> None:
+        metadata = pd.DataFrame(
+            {
+                "sequence": [np.array(["P", "E"], dtype=object)],
+                "prediction": [np.array(["P", "E"], dtype=object)],
+            }
+        )
+        utils.finalize_peptide_metadata(
+            metadata,
+            metrics,
+            has_labels=True,
+            residue_remapping=REMAPPING,
+        )
+        assert metadata["correct"].iloc[0]
+        assert isinstance(metadata["prediction"].iloc[0], list)
+
+    def test_empty_prediction_invalid(self, metrics: Metrics) -> None:
+        metadata = pd.DataFrame(
+            {
+                "sequence": [["P", "E", "P"]],
+                "prediction": [[]],
+            }
+        )
+        utils.finalize_peptide_metadata(
+            metadata,
+            metrics,
+            has_labels=True,
+            residue_remapping=REMAPPING,
+        )
+        assert not metadata["valid_prediction"].iloc[0]
+        assert metadata["num_matches"].iloc[0] == 0
+
+    def test_unlabelled_sets_valid_prediction_only(self, metrics: Metrics) -> None:
+        metadata = pd.DataFrame({"prediction": [["A", "G"]]})
+        utils.finalize_peptide_metadata(
+            metadata,
+            metrics,
+            has_labels=False,
+            residue_remapping=REMAPPING,
+        )
+        assert metadata["valid_prediction"].iloc[0]
+        assert "valid_sequence" not in metadata.columns

--- a/tests/datasets/data_loaders/test_utils.py
+++ b/tests/datasets/data_loaders/test_utils.py
@@ -115,6 +115,18 @@ class TestNormalizePeptideCell:
         )
         assert tokens == ["A", "I"]
 
+    def test_string_leucine_mapped_without_corrupting_mod_names(
+        self, metrics: Metrics
+    ) -> None:
+        """Uppercase L inside a modification name must not be rewritten before split."""
+        remapping = {"C[Labelled]": "C[UniMod:999]"}
+        tokens = utils.normalize_peptide_cell(
+            "AC[Labelled]L",
+            metrics,
+            residue_remapping=remapping,
+        )
+        assert tokens == ["A", "C[UniMod:999]", "I"]
+
     def test_modification_remapping_on_list_input(self, metrics: Metrics) -> None:
         tokens = utils.normalize_peptide_cell(
             ["M[Oxidation]", "A"],

--- a/tests/datasets/data_loaders/test_utils.py
+++ b/tests/datasets/data_loaders/test_utils.py
@@ -8,7 +8,7 @@ import pytest
 from instanovo.utils.metrics import Metrics
 from instanovo.utils.residues import ResidueSet
 
-from winnow.datasets.data_loaders import utils
+from winnow.datasets.data_loaders import utils as data_utils
 
 RESIDUE_MASSES = {
     "A": 71.037114,
@@ -35,27 +35,27 @@ class TestHasGroundTruthSequenceLabels:
 
     def test_true_when_sequence_has_content(self):
         df = pl.DataFrame({"sequence": ["PEPTIDE"], "charge": [2]})
-        assert utils.has_ground_truth_sequence_labels(df) is True
+        assert data_utils.has_ground_truth_sequence_labels(df) is True
 
     def test_true_when_sequence_has_at_least_one_non_empty_value(self):
         df = pl.DataFrame({"sequence": ["PEPTIDE", "", None], "charge": [2, 3, 4]})
-        assert utils.has_ground_truth_sequence_labels(df) is True
+        assert data_utils.has_ground_truth_sequence_labels(df) is True
         assert len(df) == 3
 
     def test_false_when_sequence_column_missing(self):
         df = pl.DataFrame({"charge": [2]})
-        assert utils.has_ground_truth_sequence_labels(df) is False
+        assert data_utils.has_ground_truth_sequence_labels(df) is False
 
     def test_false_when_sequence_column_all_empty(self):
         df = pl.DataFrame({"sequence": ["", "   ", None], "charge": [2, 3, 4]})
-        assert utils.has_ground_truth_sequence_labels(df) is False
+        assert data_utils.has_ground_truth_sequence_labels(df) is False
 
     def test_load_spectrum_data_drops_empty_sequence_column(self, tmp_path):
         df = pl.DataFrame({"sequence": ["", None], "charge": [2, 3]})
         path = tmp_path / "empty_labels.parquet"
         df.write_parquet(path)
 
-        loaded, has_labels = utils.load_spectrum_data(path)
+        loaded, has_labels = data_utils.load_spectrum_data(path)
 
         assert has_labels is False
         assert "sequence" not in loaded.columns
@@ -74,7 +74,7 @@ class TestIsValidPeptideTokens:
         ],
     )
     def test_valid_non_empty_containers(self, value: object) -> None:
-        assert utils.is_valid_peptide_tokens(value) is True
+        assert data_utils.is_valid_peptide_tokens(value) is True
 
     @pytest.mark.parametrize(
         "value",
@@ -90,17 +90,17 @@ class TestIsValidPeptideTokens:
         ],
     )
     def test_invalid_values(self, value: object) -> None:
-        assert utils.is_valid_peptide_tokens(value) is False
+        assert data_utils.is_valid_peptide_tokens(value) is False
 
     def test_as_token_list_matches_validity(self):
-        assert utils.is_valid_peptide_tokens(["A", "G"]) == (
-            utils.as_token_list(["A", "G"]) is not None
+        assert data_utils.is_valid_peptide_tokens(["A", "G"]) == (
+            data_utils.as_token_list(["A", "G"]) is not None
         )
 
 
 class TestNormalizePeptideCell:
     def test_string_splits_and_remaps(self, metrics: Metrics) -> None:
-        tokens = utils.normalize_peptide_cell(
+        tokens = data_utils.normalize_peptide_cell(
             "AG",
             metrics,
             residue_remapping=REMAPPING,
@@ -108,7 +108,7 @@ class TestNormalizePeptideCell:
         assert tokens == ["A", "G"]
 
     def test_leucine_mapped_at_token_level(self, metrics: Metrics) -> None:
-        tokens = utils.normalize_peptide_cell(
+        tokens = data_utils.normalize_peptide_cell(
             ["A", "L"],
             metrics,
             residue_remapping=REMAPPING,
@@ -120,7 +120,7 @@ class TestNormalizePeptideCell:
     ) -> None:
         """Uppercase L inside a modification name must not be rewritten before split."""
         remapping = {"C[Labelled]": "C[UniMod:999]"}
-        tokens = utils.normalize_peptide_cell(
+        tokens = data_utils.normalize_peptide_cell(
             "AC[Labelled]L",
             metrics,
             residue_remapping=remapping,
@@ -128,7 +128,7 @@ class TestNormalizePeptideCell:
         assert tokens == ["A", "C[UniMod:999]", "I"]
 
     def test_modification_remapping_on_list_input(self, metrics: Metrics) -> None:
-        tokens = utils.normalize_peptide_cell(
+        tokens = data_utils.normalize_peptide_cell(
             ["M[Oxidation]", "A"],
             metrics,
             residue_remapping=REMAPPING,
@@ -137,7 +137,7 @@ class TestNormalizePeptideCell:
 
     def test_require_label_false_for_absent(self, metrics: Metrics) -> None:
         assert (
-            utils.normalize_peptide_cell(
+            data_utils.normalize_peptide_cell(
                 None,
                 metrics,
                 residue_remapping=REMAPPING,
@@ -156,7 +156,7 @@ class TestNormalizePeptideCell:
     def test_accepts_ndarray_and_polars_series(
         self, metrics: Metrics, value: object
     ) -> None:
-        tokens = utils.normalize_peptide_cell(
+        tokens = data_utils.normalize_peptide_cell(
             value,
             metrics,
             residue_remapping=REMAPPING,
@@ -167,38 +167,38 @@ class TestNormalizePeptideCell:
 class TestCoerceBoolLabels:
     def test_bool_series_passes(self):
         series = pd.Series([True, False, True])
-        result = utils.coerce_bool_labels(series, "correct")
+        result = data_utils.coerce_bool_labels(series, "correct")
         assert result.dtype == bool
         assert result.tolist() == [True, False, True]
 
     def test_numeric_zero_one_passes(self):
         series = pd.Series([1, 0, 1.0])
-        result = utils.coerce_bool_labels(series, "proteome_hit")
+        result = data_utils.coerce_bool_labels(series, "proteome_hit")
         assert result.tolist() == [True, False, True]
 
     def test_object_bool_cells_pass(self):
         series = pd.Series([True, False], dtype=object)
-        result = utils.coerce_bool_labels(series, "proteome_hit")
+        result = data_utils.coerce_bool_labels(series, "proteome_hit")
         assert result.tolist() == [True, False]
 
     def test_nullable_boolean_with_na_raises(self):
         series = pd.Series([True, pd.NA, False], dtype="boolean")
         with pytest.raises(ValueError, match="contains missing values"):
-            utils.coerce_bool_labels(series, "proteome_hit")
+            data_utils.coerce_bool_labels(series, "proteome_hit")
 
     def test_none_in_object_series_raises(self):
         series = pd.Series([True, None, False])
         with pytest.raises(ValueError, match="contains missing values"):
-            utils.coerce_bool_labels(series, "proteome_hit")
+            data_utils.coerce_bool_labels(series, "proteome_hit")
 
     def test_string_labels_raise(self):
         series = pd.Series(["true", "false"])
         with pytest.raises(ValueError, match="must be a boolean or numeric series"):
-            utils.coerce_bool_labels(series, "proteome_hit")
+            data_utils.coerce_bool_labels(series, "proteome_hit")
 
     def test_empty_series_passes(self):
         series = pd.Series([], dtype=bool)
-        result = utils.coerce_bool_labels(series, "correct")
+        result = data_utils.coerce_bool_labels(series, "correct")
         assert result.tolist() == []
 
 
@@ -211,7 +211,7 @@ class TestLabelledTrainingMask:
             }
         )
         with pytest.raises(ValueError, match="'valid_sequence' column"):
-            utils.labelled_training_mask(metadata)
+            data_utils.labelled_training_mask(metadata)
 
     def test_requires_correct_when_sequence_present(self):
         metadata = pd.DataFrame(
@@ -221,7 +221,7 @@ class TestLabelledTrainingMask:
             }
         )
         with pytest.raises(ValueError, match="'correct' column"):
-            utils.labelled_training_mask(metadata)
+            data_utils.labelled_training_mask(metadata)
 
     def test_uses_existing_valid_sequence_column(self):
         metadata = pd.DataFrame(
@@ -231,12 +231,16 @@ class TestLabelledTrainingMask:
                 "correct": [True, False, False],
             }
         )
-        assert utils.labelled_training_mask(metadata).tolist() == [True, False, True]
+        assert data_utils.labelled_training_mask(metadata).tolist() == [
+            True,
+            False,
+            True,
+        ]
         assert "valid_sequence" in metadata.columns
 
     def test_all_rows_eligible_without_sequence_column(self):
         metadata = pd.DataFrame({"confidence": [0.9, 0.8]})
-        assert utils.labelled_training_mask(metadata).tolist() == [True, True]
+        assert data_utils.labelled_training_mask(metadata).tolist() == [True, True]
 
     def test_require_labelled_rows_raises_when_empty(self):
         metadata = pd.DataFrame(
@@ -247,7 +251,7 @@ class TestLabelledTrainingMask:
             }
         )
         with pytest.raises(ValueError, match="valid_sequence=True"):
-            utils.require_labelled_rows(metadata, context="Test context")
+            data_utils.require_labelled_rows(metadata, context="Test context")
 
     def test_require_labelled_rows_returns_mask_when_eligible(self):
         metadata = pd.DataFrame(
@@ -257,14 +261,14 @@ class TestLabelledTrainingMask:
                 "correct": [True, False],
             }
         )
-        mask = utils.require_labelled_rows(metadata, context="Test context")
+        mask = data_utils.require_labelled_rows(metadata, context="Test context")
         assert mask.tolist() == [True, False]
 
 
 class TestRowEvaluation:
     def test_row_num_matches_and_correct(self, metrics: Metrics) -> None:
         assert (
-            utils.row_num_matches(
+            data_utils.row_num_matches(
                 ["A", "G"],
                 ["A", "G"],
                 metrics,
@@ -274,7 +278,7 @@ class TestRowEvaluation:
             == 2
         )
         assert (
-            utils.row_num_matches(
+            data_utils.row_num_matches(
                 ["A", "G"],
                 ["A", "G"],
                 metrics,
@@ -283,10 +287,10 @@ class TestRowEvaluation:
             )
             == 0
         )
-        assert utils.row_is_correct(
+        assert data_utils.row_is_correct(
             2, ["A", "G"], ["A", "G"], sequence_valid=True, prediction_valid=True
         )
-        assert not utils.row_is_correct(
+        assert not data_utils.row_is_correct(
             1, ["A", "G"], ["A", "G"], sequence_valid=True, prediction_valid=True
         )
 
@@ -301,7 +305,7 @@ class TestFinalizePeptideMetadata:
 
     def test_pandas_frame(self, metrics: Metrics, labelled_fixture: dict) -> None:
         metadata = pd.DataFrame(labelled_fixture)
-        utils.finalize_peptide_metadata(
+        data_utils.finalize_peptide_metadata(
             metadata,
             metrics,
             has_labels=True,
@@ -315,7 +319,7 @@ class TestFinalizePeptideMetadata:
 
     def test_polars_frame(self, metrics: Metrics, labelled_fixture: dict) -> None:
         metadata = pl.DataFrame(labelled_fixture)
-        result = utils.finalize_peptide_metadata(
+        result = data_utils.finalize_peptide_metadata(
             metadata,
             metrics,
             has_labels=True,
@@ -334,7 +338,7 @@ class TestFinalizePeptideMetadata:
                 "prediction": [np.array(["P", "E"], dtype=object)],
             }
         )
-        utils.finalize_peptide_metadata(
+        data_utils.finalize_peptide_metadata(
             metadata,
             metrics,
             has_labels=True,
@@ -350,7 +354,7 @@ class TestFinalizePeptideMetadata:
                 "prediction": [[]],
             }
         )
-        utils.finalize_peptide_metadata(
+        data_utils.finalize_peptide_metadata(
             metadata,
             metrics,
             has_labels=True,
@@ -361,7 +365,7 @@ class TestFinalizePeptideMetadata:
 
     def test_unlabelled_sets_valid_prediction_only(self, metrics: Metrics) -> None:
         metadata = pd.DataFrame({"prediction": [["A", "G"]]})
-        utils.finalize_peptide_metadata(
+        data_utils.finalize_peptide_metadata(
             metadata,
             metrics,
             has_labels=False,

--- a/tests/datasets/data_loaders/test_utils.py
+++ b/tests/datasets/data_loaders/test_utils.py
@@ -153,16 +153,17 @@ class TestNormalizePeptideCell:
 
 
 class TestLabelledTrainingMask:
-    def test_imputes_valid_sequence_from_sequence(self):
+    def test_requires_valid_sequence_when_sequence_present(self):
         metadata = pd.DataFrame({"sequence": [["A"], None, ["B"]]})
-        assert utils.labelled_training_mask(metadata).tolist() == [True, False, True]
-        assert metadata["valid_sequence"].tolist() == [True, False, True]
+        with pytest.raises(ValueError, match="valid_sequence"):
+            utils.labelled_training_mask(metadata)
 
     def test_uses_existing_valid_sequence_column(self):
         metadata = pd.DataFrame(
             {"valid_sequence": [True, False, True], "sequence": [["A"], None, ["B"]]}
         )
         assert utils.labelled_training_mask(metadata).tolist() == [True, False, True]
+        assert "valid_sequence" in metadata.columns
 
     def test_require_labelled_rows_raises_when_empty(self):
         metadata = pd.DataFrame(

--- a/tests/datasets/data_loaders/test_utils.py
+++ b/tests/datasets/data_loaders/test_utils.py
@@ -154,26 +154,61 @@ class TestNormalizePeptideCell:
 
 class TestLabelledTrainingMask:
     def test_requires_valid_sequence_when_sequence_present(self):
-        metadata = pd.DataFrame({"sequence": [["A"], None, ["B"]]})
-        with pytest.raises(ValueError, match="valid_sequence"):
+        metadata = pd.DataFrame(
+            {
+                "sequence": [["A"], None, ["B"]],
+                "correct": [True, False, False],
+            }
+        )
+        with pytest.raises(ValueError, match="'valid_sequence' column"):
+            utils.labelled_training_mask(metadata)
+
+    def test_requires_correct_when_sequence_present(self):
+        metadata = pd.DataFrame(
+            {
+                "sequence": [["A"], None, ["B"]],
+                "valid_sequence": [True, False, True],
+            }
+        )
+        with pytest.raises(ValueError, match="'correct' column"):
             utils.labelled_training_mask(metadata)
 
     def test_uses_existing_valid_sequence_column(self):
         metadata = pd.DataFrame(
-            {"valid_sequence": [True, False, True], "sequence": [["A"], None, ["B"]]}
+            {
+                "valid_sequence": [True, False, True],
+                "sequence": [["A"], None, ["B"]],
+                "correct": [True, False, False],
+            }
         )
         assert utils.labelled_training_mask(metadata).tolist() == [True, False, True]
         assert "valid_sequence" in metadata.columns
+
+    def test_all_rows_eligible_without_sequence_column(self):
+        metadata = pd.DataFrame({"confidence": [0.9, 0.8]})
+        assert utils.labelled_training_mask(metadata).tolist() == [True, True]
 
     def test_require_labelled_rows_raises_when_empty(self):
         metadata = pd.DataFrame(
             {
                 "sequence": [None],
                 "valid_sequence": [False],
+                "correct": [False],
             }
         )
         with pytest.raises(ValueError, match="valid_sequence=True"):
             utils.require_labelled_rows(metadata, context="Test context")
+
+    def test_require_labelled_rows_returns_mask_when_eligible(self):
+        metadata = pd.DataFrame(
+            {
+                "sequence": [["A"], None],
+                "valid_sequence": [True, False],
+                "correct": [True, False],
+            }
+        )
+        mask = utils.require_labelled_rows(metadata, context="Test context")
+        assert mask.tolist() == [True, False]
 
 
 class TestRowEvaluation:

--- a/tests/datasets/data_loaders/test_winnow.py
+++ b/tests/datasets/data_loaders/test_winnow.py
@@ -100,6 +100,16 @@ class TestWinnowDatasetLoader:
         assert isinstance(dataset.metadata["sequence"].iloc[0], list)
         assert dataset.metadata["sequence"].iloc[0] == ["A", "G"]
 
+    def test_labelled_reload_computes_correct_and_num_matches(
+        self, loader, metadata_dir_with_sequence
+    ):
+        """Reload finalisation writes match labels for annotated metadata."""
+        dataset = loader.load(data_path=metadata_dir_with_sequence)
+        assert dataset.metadata["valid_prediction"].tolist() == [True, True]
+        assert dataset.metadata["valid_sequence"].tolist() == [True, True]
+        assert dataset.metadata["correct"].tolist() == [True, True]
+        assert dataset.metadata["num_matches"].tolist() == [2, 2]
+
     def test_mz_array_parsed_comma_format(self, loader, metadata_dir):
         """mz_array written with commas should be parsed to a Python list."""
         dataset = loader.load(data_path=metadata_dir)

--- a/tests/datasets/test_calibration_dataset.py
+++ b/tests/datasets/test_calibration_dataset.py
@@ -312,6 +312,18 @@ class TestCalibrationDataset:
         saved_df = pd.read_parquet(parquet_path)
         assert len(saved_df) == len(calibration_dataset.metadata)
 
+    def test_save_metadata_parquet(self, calibration_dataset, tmp_path):
+        """Test save_metadata writes processed metadata to parquet."""
+        parquet_path = tmp_path / "processed_metadata.parquet"
+
+        calibration_dataset.save_metadata(parquet_path)
+
+        assert parquet_path.exists()
+        saved_df = pd.read_parquet(parquet_path)
+        assert len(saved_df) == len(calibration_dataset.metadata)
+        assert "valid_sequence" not in saved_df.columns
+        assert "valid_prediction" not in saved_df.columns
+
     def test_length_consistency(self, calibration_dataset):
         """Test that length is consistent between metadata and predictions."""
         # This should not raise an assertion error

--- a/tests/datasets/test_calibration_dataset.py
+++ b/tests/datasets/test_calibration_dataset.py
@@ -328,6 +328,59 @@ class TestCalibrationDataset:
         assert "valid_sequence" not in saved_df.columns
         assert "valid_prediction" not in saved_df.columns
 
+    def test_format_metadata_for_export(self):
+        """Test export formatting converts peptides and drops internal columns."""
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.9, 0.8, 0.7],
+                "prediction": [
+                    ["[UNIMOD:1]", "P", "E", "P", "T", "I", "D", "E"],
+                    ["M[UNIMOD:35]", "P", "E", "P", "T", "I", "D", "E"],
+                    ["P", "E", "P", "T", "I", "D", "E", "[UNIMOD:2]"],
+                ],
+                "sequence": [
+                    ["P", "E", "P", "T", "I", "D", "E"],
+                    ["M[UNIMOD:35]", "P", "E", "P", "T", "I", "D", "E"],
+                    ["P", "E", "P", "T", "I", "D", "E", "[UNIMOD:2]"],
+                ],
+                "prediction_untokenised": [
+                    "[UNIMOD:1]-PEPTIDE",
+                    "M[UNIMOD:35]PEPTIDE",
+                    "PEPTIDE-[UNIMOD:2]",
+                ],
+            }
+        )
+        dataset = CalibrationDataset(metadata=metadata, predictions=None)
+
+        formatted = dataset.format_metadata_for_export()
+
+        assert "valid_sequence" not in formatted.columns
+        assert "valid_prediction" not in formatted.columns
+        assert "prediction_untokenised" not in formatted.columns
+        assert formatted["prediction"].tolist() == [
+            "[UNIMOD:1]-PEPTIDE",
+            "M[UNIMOD:35]PEPTIDE",
+            "PEPTIDE-[UNIMOD:2]",
+        ]
+        assert formatted["sequence"].tolist() == [
+            "PEPTIDE",
+            "M[UNIMOD:35]PEPTIDE",
+            "PEPTIDE-[UNIMOD:2]",
+        ]
+        # Original dataset remains tokenised / unmutated
+        assert dataset.metadata["prediction"].iloc[0] == [
+            "[UNIMOD:1]",
+            "P",
+            "E",
+            "P",
+            "T",
+            "I",
+            "D",
+            "E",
+        ]
+        assert "valid_prediction" in dataset.metadata.columns
+        assert "prediction_untokenised" in dataset.metadata.columns
+
     def test_length_consistency(self, calibration_dataset):
         """Test that length is consistent between metadata and predictions."""
         # This should not raise an assertion error

--- a/tests/datasets/test_calibration_dataset.py
+++ b/tests/datasets/test_calibration_dataset.py
@@ -383,17 +383,17 @@ class TestCalibrationDataset:
 
     def test_length_consistency(self, calibration_dataset):
         """Test that length is consistent between metadata and predictions."""
-        # This should not raise an assertion error
+        # This should not raise an error
         assert len(calibration_dataset) == len(calibration_dataset.metadata)
         assert len(calibration_dataset) == len(calibration_dataset.predictions)
 
     def test_length_inconsistency_raises_error(self, sample_metadata):
-        """Test that length inconsistency raises assertion error."""
+        """Test that length inconsistency raises ValueError."""
         # Create mismatched lengths
         short_predictions = [None, None]  # Only 2 predictions for 5 metadata rows
 
         with pytest.raises(
-            AssertionError, match="Length of metadata and predictions must match"
+            ValueError, match="Length of metadata and predictions must match"
         ):
             CalibrationDataset(metadata=sample_metadata, predictions=short_predictions)
 

--- a/tests/datasets/test_calibration_dataset.py
+++ b/tests/datasets/test_calibration_dataset.py
@@ -257,7 +257,8 @@ class TestCalibrationDataset:
         """Test that accessing beam[0] on empty beam raises helpful error."""
         # Create a dataset with an empty beam (empty list instead of None)
         empty_beam_dataset = CalibrationDataset(
-            metadata=pd.DataFrame({"confidence": [0.5]}), predictions=[[]]
+            metadata=pd.DataFrame({"confidence": [0.5], "prediction": [["A"]]}),
+            predictions=[[]],
         )
         with pytest.raises(ValueError, match="beam is empty"):
             empty_beam_dataset.filter_entries(
@@ -272,7 +273,7 @@ class TestCalibrationDataset:
         """Test that accessing beam[1] when beam has only 1 element raises helpful error."""
         # Create a dataset with a beam that has only 1 element
         short_beam_dataset = CalibrationDataset(
-            metadata=pd.DataFrame({"confidence": [0.5]}),
+            metadata=pd.DataFrame({"confidence": [0.5], "prediction": [["A"]]}),
             predictions=[[MockScoredSequence(["A"], np.log(0.8))]],
         )
         with pytest.raises(ValueError, match="too short"):
@@ -284,7 +285,10 @@ class TestCalibrationDataset:
 
     def test_filter_entries_handles_empty_dataset(self):
         """Test that filtering an empty dataset returns an empty dataset."""
-        empty_dataset = CalibrationDataset(metadata=pd.DataFrame(), predictions=[])
+        empty_dataset = CalibrationDataset(
+            metadata=pd.DataFrame({"prediction": pd.Series(dtype=object)}),
+            predictions=[],
+        )
         filtered = empty_dataset.filter_entries(lambda row: True)
         assert len(filtered) == 0
 
@@ -342,7 +346,7 @@ class TestCalibrationDataset:
 
     def test_empty_dataset(self):
         """Test operations on empty dataset."""
-        empty_metadata = pd.DataFrame()
+        empty_metadata = pd.DataFrame({"prediction": pd.Series(dtype=object)})
         empty_dataset = CalibrationDataset(metadata=empty_metadata, predictions=[])
 
         assert len(empty_dataset) == 0
@@ -422,7 +426,7 @@ class TestCalibrationDataset:
 
     def test_predictions_none_default(self):
         """Test that predictions defaults to None."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         dataset = CalibrationDataset(metadata=metadata)
 
         assert dataset.predictions is None

--- a/tests/datasets/test_calibration_dataset_peptide_contract.py
+++ b/tests/datasets/test_calibration_dataset_peptide_contract.py
@@ -1,0 +1,103 @@
+"""Unit tests for CalibrationDataset peptide structure validation."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from winnow.datasets.calibration_dataset import CalibrationDataset
+
+
+class TestCalibrationDatasetPeptideContract:
+    def test_requires_prediction_column(self) -> None:
+        with pytest.raises(ValueError, match="requires a 'prediction' column"):
+            CalibrationDataset(metadata=pd.DataFrame({"confidence": [0.9]}))
+
+    def test_rejects_raw_prediction_strings(self) -> None:
+        with pytest.raises(ValueError, match="raw strings"):
+            CalibrationDataset(
+                metadata=pd.DataFrame(
+                    {"confidence": [0.9], "prediction": ["AG"]},
+                )
+            )
+
+    def test_normalises_empty_prediction_containers_to_none(self) -> None:
+        dataset = CalibrationDataset(
+            metadata=pd.DataFrame(
+                {"confidence": [0.9], "prediction": [[]]},
+            )
+        )
+        assert dataset.metadata["prediction"].tolist() == [None]
+        assert dataset.metadata["valid_prediction"].tolist() == [False]
+
+    def test_normalises_empty_sequence_containers_to_none(self) -> None:
+        dataset = CalibrationDataset(
+            metadata=pd.DataFrame(
+                {
+                    "confidence": [0.9],
+                    "prediction": [["A", "G"]],
+                    "sequence": [[]],
+                }
+            )
+        )
+        assert dataset.metadata["sequence"].tolist() == [None]
+        assert dataset.metadata["valid_sequence"].tolist() == [False]
+
+    def test_rejects_unsupported_prediction_values(self) -> None:
+        with pytest.raises(ValueError, match="unsupported value"):
+            CalibrationDataset(
+                metadata=pd.DataFrame(
+                    {"confidence": [0.9], "prediction": [42]},
+                )
+            )
+
+    def test_accepts_token_lists_and_derives_valid_prediction(self) -> None:
+        dataset = CalibrationDataset(
+            metadata=pd.DataFrame(
+                {
+                    "confidence": [0.9, 0.8],
+                    "prediction": [["A", "G"], None],
+                }
+            )
+        )
+        assert dataset.metadata["valid_prediction"].tolist() == [True, False]
+
+    def test_derives_valid_sequence_when_labelled(self) -> None:
+        dataset = CalibrationDataset(
+            metadata=pd.DataFrame(
+                {
+                    "confidence": [0.9, 0.8],
+                    "prediction": [["A", "G"], ["A", "G"]],
+                    "sequence": [["A", "G"], None],
+                }
+            )
+        )
+        assert dataset.metadata["valid_sequence"].tolist() == [True, False]
+        assert dataset.metadata["valid_prediction"].tolist() == [True, True]
+
+    def test_overwrites_stale_valid_prediction_with_warning(self) -> None:
+        with pytest.warns(UserWarning, match="valid_prediction"):
+            dataset = CalibrationDataset(
+                metadata=pd.DataFrame(
+                    {
+                        "confidence": [0.9],
+                        "prediction": [["A", "G"]],
+                        "valid_prediction": [False],
+                    }
+                )
+            )
+        assert dataset.metadata["valid_prediction"].tolist() == [True]
+
+    def test_overwrites_stale_valid_sequence_with_warning(self) -> None:
+        with pytest.warns(UserWarning, match="valid_sequence"):
+            dataset = CalibrationDataset(
+                metadata=pd.DataFrame(
+                    {
+                        "confidence": [0.9],
+                        "prediction": [["A", "G"]],
+                        "sequence": [["A", "G"]],
+                        "valid_sequence": [False],
+                    }
+                )
+            )
+        assert dataset.metadata["valid_sequence"].tolist() == [True]

--- a/tests/fdr/test_database_grounded.py
+++ b/tests/fdr/test_database_grounded.py
@@ -84,6 +84,56 @@ class TestDatabaseGroundedFDRControl:
         with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
             db_fdr_control.fit(empty_data)
 
+    def test_fit_imputes_valid_sequence_correct_and_num_matches(self, db_fdr_control):
+        """Sequence-derived fit imputes validity and per-row labels on all rows."""
+        dataset = pd.DataFrame(
+            {
+                "sequence": [list("PEPTIDE"), None, []],
+                "prediction": [list("PEPTIDE"), list("AG"), list("AG")],
+                "confidence": [0.9, 0.8, 0.7],
+            }
+        )
+        db_fdr_control.fit(dataset)
+
+        assert dataset["valid_sequence"].tolist() == [True, False, False]
+        assert db_fdr_control.preds["correct"].tolist() == [True, False, False]
+        assert dataset["num_matches"].tolist() == [7, 0, 0]
+
+    def test_fit_excludes_invalid_sequence_rows_from_fdr_curve(self):
+        """Rows with valid_sequence=False must not enter the precision curve."""
+        ctrl = DatabaseGroundedFDRControl(
+            confidence_feature="confidence",
+            residue_masses={
+                "P": 97.052764,
+                "E": 129.042593,
+                "T": 101.047670,
+                "I": 113.084064,
+                "D": 115.026943,
+            },
+            drop=0,
+        )
+        dataset = pd.DataFrame(
+            {
+                "sequence": [list("PEPTIDE"), None],
+                "prediction": [list("PEPTIDE"), list("WRONG")],
+                "confidence": [0.9, 0.99],
+            }
+        )
+        ctrl.fit(dataset)
+        assert ctrl._fdr_values.tolist() == [0.0]
+        assert ctrl._confidence_scores.tolist() == [0.9]
+
+    def test_fit_raises_when_no_valid_ground_truth_sequences(self, db_fdr_control):
+        dataset = pd.DataFrame(
+            {
+                "sequence": [None, []],
+                "prediction": [list("AG"), list("AG")],
+                "confidence": [0.9, 0.8],
+            }
+        )
+        with pytest.raises(ValueError, match="valid_sequence=True"):
+            db_fdr_control.fit(dataset)
+
     def test_get_confidence_cutoff_requires_fitting(self, db_fdr_control):
         """Test that get_confidence_cutoff requires fitting first."""
         # Should raise AttributeError if not fitted

--- a/tests/fdr/test_database_grounded.py
+++ b/tests/fdr/test_database_grounded.py
@@ -80,7 +80,7 @@ class TestDatabaseGroundedFDRControl:
                 }
             )
         )
-        with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
+        with pytest.raises(ValueError, match="Fit method requires non-empty data"):
             db_fdr_control.fit(empty_data)
 
     def test_fit_requires_finalised_metadata(self, db_fdr_control):

--- a/tests/fdr/test_database_grounded.py
+++ b/tests/fdr/test_database_grounded.py
@@ -2,7 +2,12 @@
 
 import pytest
 import pandas as pd
+from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.fdr.database_grounded import DatabaseGroundedFDRControl
+
+
+def _as_dataset(df: pd.DataFrame) -> CalibrationDataset:
+    return CalibrationDataset(metadata=df)
 
 
 class TestDatabaseGroundedFDRControl:
@@ -11,33 +16,18 @@ class TestDatabaseGroundedFDRControl:
     @pytest.fixture()
     def db_fdr_control(self):
         """Create a DatabaseGroundedFDRControl instance for testing."""
-        residue_masses = {
-            "G": 57.021464,
-            "A": 71.037114,
-            "P": 97.052764,
-            "E": 129.042593,
-            "T": 101.047670,
-            "I": 113.084064,
-            "D": 115.026943,
-            "R": 156.101111,
-            "O": 237.147727,
-            "N": 114.042927,
-            "S": 87.032028,
-            "M": 131.040485,
-            "L": 113.084064,
-        }
-        return DatabaseGroundedFDRControl(
-            confidence_feature="confidence", residue_masses=residue_masses
-        )
+        return DatabaseGroundedFDRControl(confidence_feature="confidence", drop=0)
 
     @pytest.fixture()
     def sample_dataset_df(self):
-        """Create a sample dataset DataFrame for testing."""
+        """Finalised sample dataset DataFrame for testing."""
         return pd.DataFrame(
             {
-                "sequence": ["PEPTIDE", "PROTEIN", "SAMPLE"],
-                "prediction": ["PEPTIDE", "PROTIEN", "SAMPL"],  # One mismatch
+                "sequence": [list("PEPTIDE"), list("PROTEIN"), list("SAMPLE")],
+                "prediction": [list("PEPTIDE"), list("PROTIEN"), list("SAMPL")],
                 "confidence": [0.9, 0.8, 0.7],
+                "correct": [True, False, False],
+                "valid_sequence": [True, True, True],
                 "precursor_mz": [500.504, 400.672, 400.504],
                 "precursor_charge": [2, 3, 2],
             }
@@ -51,14 +41,8 @@ class TestDatabaseGroundedFDRControl:
 
     def test_fit_basic(self, db_fdr_control, sample_dataset_df):
         """Test basic fitting functionality."""
-        # Convert sequences to list format as expected by the implementation
-        sample_dataset_df = sample_dataset_df.copy()
-        sample_dataset_df["prediction"] = sample_dataset_df["prediction"].apply(list)
+        db_fdr_control.fit(_as_dataset(sample_dataset_df))
 
-        # Should not raise an exception
-        db_fdr_control.fit(sample_dataset_df)
-
-        # Check that fit created the required attributes
         assert hasattr(db_fdr_control, "preds")
         assert hasattr(db_fdr_control, "_fdr_values")
         assert hasattr(db_fdr_control, "_confidence_scores")
@@ -68,75 +52,86 @@ class TestDatabaseGroundedFDRControl:
     def test_fit_with_parameters(self, db_fdr_control):
         """Test fit with custom parameters."""
         sample_df = pd.DataFrame(
-            {"sequence": ["TEST"], "prediction": [list("TEST")], "confidence": [0.9]}
+            {
+                "sequence": [list("TEST")],
+                "prediction": [list("TEST")],
+                "confidence": [0.9],
+                "correct": [True],
+                "valid_sequence": [True],
+            }
         )
 
-        db_fdr_control.fit(sample_df)
+        db_fdr_control.fit(_as_dataset(sample_df))
 
-        # Check that fit created the required attributes
         assert hasattr(db_fdr_control, "preds")
         assert len(db_fdr_control.preds) == 1
         assert db_fdr_control.preds.iloc[0]["confidence"] == 0.9
 
     def test_fit_with_empty_data(self, db_fdr_control):
         """Test that fit method handles empty data."""
-        empty_data = pd.DataFrame()
+        empty_data = _as_dataset(
+            pd.DataFrame(
+                {
+                    "prediction": pd.Series([], dtype=object),
+                    "sequence": pd.Series([], dtype=object),
+                    "correct": pd.Series([], dtype=bool),
+                    "valid_sequence": pd.Series([], dtype=bool),
+                    "confidence": pd.Series([], dtype=float),
+                }
+            )
+        )
         with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
             db_fdr_control.fit(empty_data)
 
-    def test_fit_imputes_valid_sequence_correct_and_num_matches(self, db_fdr_control):
-        """Sequence-derived fit imputes validity and per-row labels on all rows."""
-        dataset = pd.DataFrame(
-            {
-                "sequence": [list("PEPTIDE"), None, []],
-                "prediction": [list("PEPTIDE"), list("AG"), list("AG")],
-                "confidence": [0.9, 0.8, 0.7],
-            }
+    def test_fit_requires_finalised_metadata(self, db_fdr_control):
+        """Fit refuses metadata missing loader-derived correctness labels."""
+        dataset = _as_dataset(
+            pd.DataFrame(
+                {
+                    "sequence": [list("PEPTIDE")],
+                    "prediction": [list("PEPTIDE")],
+                    "confidence": [0.9],
+                }
+            )
         )
-        db_fdr_control.fit(dataset)
-
-        assert dataset["valid_sequence"].tolist() == [True, False, False]
-        assert db_fdr_control.preds["correct"].tolist() == [True, False, False]
-        assert dataset["num_matches"].tolist() == [7, 0, 0]
+        with pytest.raises(ValueError, match="finalised labelled metadata"):
+            db_fdr_control.fit(dataset)
 
     def test_fit_excludes_invalid_sequence_rows_from_fdr_curve(self):
         """Rows with valid_sequence=False must not enter the precision curve."""
-        ctrl = DatabaseGroundedFDRControl(
-            confidence_feature="confidence",
-            residue_masses={
-                "P": 97.052764,
-                "E": 129.042593,
-                "T": 101.047670,
-                "I": 113.084064,
-                "D": 115.026943,
-            },
-            drop=0,
-        )
-        dataset = pd.DataFrame(
-            {
-                "sequence": [list("PEPTIDE"), None],
-                "prediction": [list("PEPTIDE"), list("WRONG")],
-                "confidence": [0.9, 0.99],
-            }
+        ctrl = DatabaseGroundedFDRControl(confidence_feature="confidence", drop=0)
+        dataset = _as_dataset(
+            pd.DataFrame(
+                {
+                    "sequence": [list("PEPTIDE"), None],
+                    "prediction": [list("PEPTIDE"), list("WRONG")],
+                    "confidence": [0.9, 0.99],
+                    "correct": [True, False],
+                    "valid_sequence": [True, False],
+                }
+            )
         )
         ctrl.fit(dataset)
         assert ctrl._fdr_values.tolist() == [0.0]
         assert ctrl._confidence_scores.tolist() == [0.9]
 
     def test_fit_raises_when_no_valid_ground_truth_sequences(self, db_fdr_control):
-        dataset = pd.DataFrame(
-            {
-                "sequence": [None, []],
-                "prediction": [list("AG"), list("AG")],
-                "confidence": [0.9, 0.8],
-            }
+        dataset = _as_dataset(
+            pd.DataFrame(
+                {
+                    "sequence": [None, None],
+                    "prediction": [list("AG"), list("AG")],
+                    "confidence": [0.9, 0.8],
+                    "correct": [False, False],
+                    "valid_sequence": [False, False],
+                }
+            )
         )
         with pytest.raises(ValueError, match="valid_sequence=True"):
             db_fdr_control.fit(dataset)
 
     def test_get_confidence_cutoff_requires_fitting(self, db_fdr_control):
         """Test that get_confidence_cutoff requires fitting first."""
-        # Should raise AttributeError if not fitted
         with pytest.raises(
             AttributeError, match=r"FDR method not fitted, please call `fit\(\)` first"
         ):
@@ -144,7 +139,6 @@ class TestDatabaseGroundedFDRControl:
 
     def test_compute_fdr_requires_fitting(self, db_fdr_control):
         """Test that compute_fdr requires fitting first."""
-        # Should raise AttributeError if not fitted
         with pytest.raises(
             AttributeError, match=r"FDR method not fitted, please call `fit\(\)` first"
         ):

--- a/tests/fdr/test_database_grounded.py
+++ b/tests/fdr/test_database_grounded.py
@@ -96,8 +96,9 @@ class TestDatabaseGroundedFDRControl:
         db_fdr_control.fit(dataset)
 
         assert dataset["valid_sequence"].tolist() == [True, False, False]
-        assert db_fdr_control.preds["correct"].tolist() == [True, False, False]
+        assert db_fdr_control.preds["correct"].tolist() == [True]
         assert dataset["num_matches"].tolist() == [7, 0, 0]
+        assert dataset["correct"].tolist() == [True, False, False]
 
     def test_fit_excludes_invalid_sequence_rows_from_fdr_curve(self):
         """Rows with valid_sequence=False must not enter the precision curve."""

--- a/tests/fdr/test_nonparametric.py
+++ b/tests/fdr/test_nonparametric.py
@@ -16,9 +16,10 @@ class TestNonParametricFDRControl:
 
     @pytest.fixture()
     def sample_confidence_data(self):
-        """Create sample confidence data for testing."""
-        return pd.DataFrame(
-            {"confidence": [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]}
+        """Create sample confidence scores for testing."""
+        return pd.Series(
+            [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1],
+            name="confidence",
         )
 
     @pytest.fixture()
@@ -51,7 +52,7 @@ class TestNonParametricFDRControl:
 
     def test_fit_with_single_value(self, nonparametric_fdr_control):
         """Test fitting with a single confidence value."""
-        single_data = pd.DataFrame({"confidence": [0.8]})
+        single_data = pd.Series([0.8], name="confidence")
         nonparametric_fdr_control.fit(single_data)
 
         assert len(nonparametric_fdr_control._confidence_scores) == 1
@@ -59,14 +60,17 @@ class TestNonParametricFDRControl:
 
     def test_fit_with_duplicate_values(self, nonparametric_fdr_control):
         """Test fitting with duplicate confidence values."""
-        duplicate_data = pd.DataFrame({"confidence": [0.9, 0.8, 0.8, 0.7, 0.7, 0.6]})
+        duplicate_data = pd.Series(
+            [0.9, 0.8, 0.8, 0.7, 0.7, 0.6],
+            name="confidence",
+        )
         nonparametric_fdr_control.fit(duplicate_data)
 
         assert len(nonparametric_fdr_control._confidence_scores) == 6
 
     def test_fit_with_empty_data(self, nonparametric_fdr_control):
         """Test that fit method handles empty data."""
-        empty_data = pd.DataFrame({"confidence": []})
+        empty_data = pd.Series([], dtype=float, name="confidence")
         with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
             nonparametric_fdr_control.fit(empty_data)
 

--- a/tests/fdr/test_nonparametric.py
+++ b/tests/fdr/test_nonparametric.py
@@ -71,7 +71,7 @@ class TestNonParametricFDRControl:
     def test_fit_with_empty_data(self, nonparametric_fdr_control):
         """Test that fit method handles empty data."""
         empty_data = pd.Series([], dtype=float, name="confidence")
-        with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
+        with pytest.raises(ValueError, match="Fit method requires non-empty data"):
             nonparametric_fdr_control.fit(empty_data)
 
     def test_get_confidence_cutoff_requires_fitting(self, nonparametric_fdr_control):

--- a/tests/utils/test_peptide.py
+++ b/tests/utils/test_peptide.py
@@ -5,6 +5,7 @@ of peptide sequences, including N-terminal and C-terminal modifications.
 """
 
 import pytest
+import numpy as np
 
 from winnow.utils.peptide import tokens_to_proforma, _is_standalone_modification
 
@@ -60,6 +61,11 @@ class TestTokensToProforma:
         """Test empty token list returns empty string."""
         assert tokens_to_proforma([]) == ""
         assert tokens_to_proforma(None) == ""
+
+    def test_numpy_token_array(self):
+        """Test numpy arrays of tokens are coerced before ProForma conversion."""
+        tokens = np.array(["P", "E", "P", "T", "I", "D", "E"], dtype=object)
+        assert tokens_to_proforma(tokens) == "PEPTIDE"
 
     def test_single_amino_acid(self):
         """Test single amino acid."""

--- a/winnow/calibration/calibrator.py
+++ b/winnow/calibration/calibrator.py
@@ -15,6 +15,7 @@ from winnow.calibration.calibration_features import (
     FeatureDependency,
 )
 from winnow.datasets.calibration_dataset import CalibrationDataset
+from winnow.datasets.data_loaders.utils import require_labelled_rows
 
 
 class ProbabilityCalibrator:
@@ -215,10 +216,17 @@ class ProbabilityCalibrator:
 
         This method computes the features from the dataset, prepares the labels, and trains an MLP classifier for recalibrating probabilities.
 
+        Only rows with a valid ground-truth sequence (``valid_sequence=True``, derived
+        from ``sequence`` when needed) contribute to scaler and classifier fitting;
+        all rows still receive feature computation and retain their ``correct`` labels.
+
         Args:
             dataset (CalibrationDataset): The dataset used for training the classifier.
         """
         features, labels = self.compute_features(dataset=dataset, labelled=True)
+        mask = require_labelled_rows(dataset.metadata, context="Calibrator fit")
+        features = features[mask]
+        labels = labels[mask]
         # Fit and transform features with scaler
         features_scaled = self.scaler.fit_transform(features)
         self.classifier.fit(features_scaled, labels)

--- a/winnow/calibration/calibrator.py
+++ b/winnow/calibration/calibrator.py
@@ -216,9 +216,12 @@ class ProbabilityCalibrator:
 
         This method computes the features from the dataset, prepares the labels, and trains an MLP classifier for recalibrating probabilities.
 
-        Only rows with a valid ground-truth sequence (``valid_sequence=True``, derived
-        from ``sequence`` when needed) contribute to scaler and classifier fitting;
-        all rows still receive feature computation and retain their ``correct`` labels.
+        Only rows with a valid ground-truth sequence (``valid_sequence=True``)
+        contribute to scaler and classifier fitting. The dataset must already
+        contain finalised metadata from a DatasetLoader (tokenised peptides and,
+        for labelled data, ``valid_sequence`` / ``correct``); this method does not
+        tokenise sequences itself. All rows still receive feature computation and
+        retain their ``correct`` labels.
 
         Args:
             dataset (CalibrationDataset): The dataset used for training the classifier.

--- a/winnow/calibration/calibrator.py
+++ b/winnow/calibration/calibrator.py
@@ -16,6 +16,7 @@ from winnow.calibration.calibration_features import (
 )
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.datasets.data_loaders.utils import (
+    SEQUENCE_DERIVED_CORRECT_COLUMN,
     labelled_training_mask,
     require_labelled_rows,
 )
@@ -277,7 +278,7 @@ class ProbabilityCalibrator:
         features = dataset.metadata[feature_columns]
 
         if labelled:
-            labels = dataset.metadata["correct"]
+            labels = dataset.metadata[SEQUENCE_DERIVED_CORRECT_COLUMN]
             return features.values, labels.values
         else:
             return features.values

--- a/winnow/calibration/calibrator.py
+++ b/winnow/calibration/calibrator.py
@@ -15,7 +15,10 @@ from winnow.calibration.calibration_features import (
     FeatureDependency,
 )
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.datasets.data_loaders.utils import require_labelled_rows
+from winnow.datasets.data_loaders.utils import (
+    labelled_training_mask,
+    require_labelled_rows,
+)
 
 
 class ProbabilityCalibrator:
@@ -226,10 +229,16 @@ class ProbabilityCalibrator:
         Args:
             dataset (CalibrationDataset): The dataset used for training the classifier.
         """
+        # Validate labelled columns / eligibility before feature computation.
+        # Recompute the mask afterwards in case feature computation drops rows.
+        require_labelled_rows(dataset.metadata, context="Calibrator fit")
         features, labels = self.compute_features(dataset=dataset, labelled=True)
-        mask = require_labelled_rows(dataset.metadata, context="Calibrator fit")
+        mask = labelled_training_mask(dataset.metadata)
         features = features[mask]
         labels = labels[mask]
+        # If no labelled rows are available, raise an error
+        if len(features) == 0:
+            raise ValueError("No labelled rows available for training")
         # Fit and transform features with scaler
         features_scaled = self.scaler.fit_transform(features)
         self.classifier.fit(features_scaled, labels)

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -16,6 +16,10 @@ from numpy.typing import NDArray
 from sklearn.isotonic import IsotonicRegression
 
 from winnow.datasets.calibration_dataset import CalibrationDataset
+from winnow.datasets.data_loaders.utils import (
+    finalize_peptide_metadata,
+    require_labelled_rows,
+)
 
 LabelSource = Literal["sequence", "precomputed"]
 SEQUENCE_LABEL_COLUMN = "correct"
@@ -90,17 +94,6 @@ def validate_label_config(
         )
 
 
-def _normalize_peptide_tokens(value: object, metrics: Metrics) -> list[str]:
-    """Normalize a sequence or prediction cell to a list of residue tokens."""
-    if isinstance(value, str):
-        return metrics._split_peptide(value)
-    if isinstance(value, (list, tuple)):
-        return list(value)
-    if isinstance(value, np.ndarray):
-        return value.tolist()
-    return []
-
-
 def compute_correct_from_sequence(
     metadata: pd.DataFrame,
     residue_masses: dict[str, float],
@@ -123,22 +116,13 @@ def compute_correct_from_sequence(
         )
     )
     df = metadata.copy()
-    df["sequence"] = df["sequence"].apply(
-        lambda value: _normalize_peptide_tokens(value, metrics)
+    finalize_peptide_metadata(
+        df,
+        metrics,
+        has_labels=True,
+        residue_remapping=residue_remapping or {},
     )
-    df["prediction"] = df["prediction"].apply(
-        lambda value: _normalize_peptide_tokens(value, metrics)
-    )
-
-    def _row_correct(row: pd.Series) -> bool:
-        sequence = row["sequence"]
-        prediction = row["prediction"]
-        if not sequence or not prediction:
-            return False
-        num_matches = metrics._novor_match(sequence, prediction)
-        return num_matches == len(sequence) == len(prediction)
-
-    return df.apply(_row_correct, axis=1)
+    return df["correct"]
 
 
 def _coerce_bool_labels(series: pd.Series, column: str) -> pd.Series:
@@ -175,7 +159,12 @@ def resolve_diagnostics_labels(
         labels = _coerce_bool_labels(metadata[label_column], label_column)
         return labels, label_column
 
-    labels = compute_correct_from_sequence(metadata, residue_masses, residue_remapping)
+    if "correct" not in metadata.columns:
+        metadata["correct"] = compute_correct_from_sequence(
+            metadata, residue_masses, residue_remapping
+        )
+    mask = require_labelled_rows(metadata, context="Sequence-derived diagnostics")
+    labels = metadata.loc[mask, "correct"].astype(bool)
     return labels, SEQUENCE_LABEL_COLUMN
 
 

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -10,16 +10,11 @@ from typing import Literal, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype
-from instanovo.utils.metrics import Metrics
-from instanovo.utils.residues import ResidueSet
 from numpy.typing import NDArray
 from sklearn.isotonic import IsotonicRegression
 
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.datasets.data_loaders.utils import (
-    finalize_peptide_metadata,
-    require_labelled_rows,
-)
+from winnow.datasets.data_loaders.utils import require_labelled_rows
 
 LabelSource = Literal["sequence", "precomputed"]
 SEQUENCE_LABEL_COLUMN = "correct"
@@ -94,37 +89,6 @@ def validate_label_config(
         )
 
 
-def compute_correct_from_sequence(
-    metadata: pd.DataFrame,
-    residue_masses: dict[str, float],
-    residue_remapping: Optional[dict[str, str]] = None,
-) -> pd.Series:
-    """Derive full-sequence correctness from sequence and prediction columns."""
-    if "sequence" not in metadata.columns:
-        raise ValueError(
-            "label_source='sequence' requires a 'sequence' column in the dataset."
-        )
-    if "prediction" not in metadata.columns:
-        raise ValueError(
-            "label_source='sequence' requires a 'prediction' column in the dataset."
-        )
-
-    metrics = Metrics(
-        residue_set=ResidueSet(
-            residue_masses=residue_masses,
-            residue_remapping=residue_remapping or {},
-        )
-    )
-    df = metadata.copy()
-    finalize_peptide_metadata(
-        df,
-        metrics,
-        has_labels=True,
-        residue_remapping=residue_remapping or {},
-    )
-    return df["correct"]
-
-
 def _coerce_bool_labels(series: pd.Series, column: str) -> pd.Series:
     if series.isna().any():
         raise ValueError(
@@ -143,10 +107,12 @@ def resolve_diagnostics_labels(
     dataset: CalibrationDataset,
     label_source: LabelSource,
     label_column: Optional[str],
-    residue_masses: dict[str, float],
-    residue_remapping: Optional[dict[str, str]] = None,
 ) -> Tuple[pd.Series, str]:
-    """Resolve boolean labels and return (labels, resolved_column_name)."""
+    """Resolve boolean labels and return (labels, resolved_column_name).
+
+    For ``label_source='sequence'``, the dataset must already contain finalised
+    ``correct`` and ``valid_sequence`` columns from a DatasetLoader.
+    """
     metadata = dataset.metadata
 
     if label_source == "precomputed":
@@ -159,9 +125,17 @@ def resolve_diagnostics_labels(
         labels = _coerce_bool_labels(metadata[label_column], label_column)
         return labels, label_column
 
-    if "correct" not in metadata.columns:
-        metadata["correct"] = compute_correct_from_sequence(
-            metadata, residue_masses, residue_remapping
+    missing = [
+        column
+        for column in ("correct", "valid_sequence")
+        if column not in metadata.columns
+    ]
+    if missing:
+        raise ValueError(
+            "This operation requires finalised labelled metadata with "
+            f"{', '.join(repr(c) for c in missing)}. "
+            "Load labelled data through a DatasetLoader before fitting/running "
+            "diagnostics."
         )
     mask = require_labelled_rows(metadata, context="Sequence-derived diagnostics")
     labels = metadata.loc[mask, "correct"].astype(bool)

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -137,6 +137,9 @@ def resolve_diagnostics_labels(
             "diagnostics."
         )
     mask = require_labelled_rows(metadata, context="Sequence-derived diagnostics")
+    # If no labelled rows are available, raise an error
+    if len(mask) == 0:
+        raise ValueError("No labelled rows available for sequence-derived diagnostics")
     labels = metadata.loc[mask, "correct"].astype(bool)
     return labels, SEQUENCE_LABEL_COLUMN
 

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -81,7 +81,6 @@ def validate_label_config(
     if label_source == "sequence" and label_column is not None:
         raise ValueError(
             "diagnostics.label_column must not be set when label_source is 'sequence'. "
-            "Sequence-derived labels are written to the 'correct' column automatically."
         )
     if label_source == "precomputed" and not label_column:
         raise ValueError(

--- a/winnow/calibration/features/mass_error.py
+++ b/winnow/calibration/features/mass_error.py
@@ -9,6 +9,7 @@ from winnow.calibration.features.constants import (
     PROTON_MASS,
 )
 from winnow.datasets.calibration_dataset import CalibrationDataset
+from winnow.datasets.data_loaders.utils import is_valid_peptide_tokens
 
 
 def _validate_dataset(dataset: CalibrationDataset) -> None:
@@ -31,20 +32,16 @@ def _compute_signed_mass_errors(
     measured_mz = dataset.metadata["precursor_mz"]
     charge = dataset.metadata["precursor_charge"]
 
-    invalid_mask = ~dataset.metadata["prediction"].apply(lambda p: isinstance(p, list))
+    invalid_mask = ~dataset.metadata["prediction"].apply(is_valid_peptide_tokens)
     if invalid_mask.any():
         n_invalid = invalid_mask.sum()
         raise ValueError(
             f"{n_invalid} prediction(s) are not valid peptide sequences "
-            f"(expected list of residue tokens)."
+            f"(expected non-empty list of residue tokens)."
         )
 
     neutral_mass = dataset.metadata["prediction"].apply(
-        lambda peptide: (
-            sum(residue_masses[residue] for residue in peptide) + H2O_MASS
-            if isinstance(peptide, list)
-            else 0.0
-        )
+        lambda peptide: sum(residue_masses[residue] for residue in peptide) + H2O_MASS
     )
     theoretical_mz = (neutral_mass + charge * PROTON_MASS) / charge
 

--- a/winnow/calibration/features/retention_time.py
+++ b/winnow/calibration/features/retention_time.py
@@ -101,6 +101,18 @@ class RetentionTimeFeature(CalibrationFeatures):
             columns.append("is_missing_irt_error")
         return columns
 
+    @staticmethod
+    def _sequence_key(row: pd.Series) -> tuple:
+        """Hashable key for a predicted peptide sequence."""
+        prediction = row["prediction"]
+        if isinstance(prediction, list):
+            return tuple(prediction)
+        if "prediction_untokenised" in row.index and pd.notna(
+            row.get("prediction_untokenised")
+        ):
+            return (str(row["prediction_untokenised"]),)
+        return (str(prediction),)
+
     def check_valid_irt_prediction(self, dataset: CalibrationDataset) -> pd.Series:
         """Check which predictions are valid for iRT prediction.
 
@@ -274,12 +286,22 @@ class RetentionTimeFeature(CalibrationFeatures):
             # All remaining rows are valid — the reindex below will find every spectrum_id
             # in predictions with no NaN fill needed.
 
+        if dataset.metadata.empty:
+            dataset.metadata["irt_error"] = pd.Series(dtype=float)
+            return
+
         original_indices = dataset.metadata.index
 
         # Filter out invalid spectra for iRT prediction
         valid_irt_input = dataset.filter_entries(
             metadata_predicate=lambda row: row["is_missing_irt_error"]
         )
+
+        if valid_irt_input.metadata.empty:
+            dataset.metadata["iRT"] = np.nan
+            dataset.metadata["predicted iRT"] = np.nan
+            dataset.metadata["irt_error"] = 0.0
+            return
 
         # Prepare input data
         inputs = pd.DataFrame()
@@ -359,6 +381,22 @@ class RetentionTimeFeature(CalibrationFeatures):
         n_train = max(1, int(self.train_fraction * len(train_data)))
         train_data = train_data.iloc[:n_train]
 
+        n_unique_peptides = self._count_unique_sequences(train_data)
+        if n_unique_peptides < 2:
+            raise ValueError(
+                f"Experiment '{experiment_name}': Cannot fit iRT calibration regressor.\n"
+                f" Training pool has only {n_unique_peptides} unique peptide(s) after applying train_fraction={self.train_fraction}.\n"
+                "  Koina iRT prediction models output one iRT per peptide sequence, so RT->iRT regression requires at least 2 distinct training peptides.\n"
+                "  Increase calibrator.irt_calibration.train_fraction or provide more peptide diversity."
+            )
+
+        if train_data["retention_time"].nunique() < 2:
+            raise ValueError(
+                f"Experiment '{experiment_name}': Cannot fit iRT calibration regressor.\n"
+                f"  training pool has only {train_data['retention_time'].nunique()} unique retention time value(s) after applying train_fraction={self.train_fraction}.\n"
+                "  Increase calibrator.irt_calibration.train_fraction."
+            )
+
         if len(train_data) < self.min_train_points:
             raise ValueError(
                 f"Experiment '{experiment_name}': insufficient data for iRT "
@@ -369,7 +407,20 @@ class RetentionTimeFeature(CalibrationFeatures):
                 f"Adjust train_fraction, min_train_points, or provide more data."
             )
 
+        if 2 <= n_unique_peptides < self.min_train_points:
+            warnings.warn(
+                f"Experiment '{experiment_name}': iRT calibration pool (top {self.train_fraction:.0%}, {len(train_data)} PSMs):\n"
+                f"  Only {n_unique_peptides} unique peptide(s), below min_train_points={self.min_train_points}.\n"
+                f"  The RT->iRT regressor fit may be unreliable.\n"
+                f"  Consider increasing calibrator.irt_calibration.train_fraction or de-duplicating peptides.",
+                stacklevel=2,
+            )
+
         return train_data
+
+    def _count_unique_sequences(self, metadata: pd.DataFrame) -> int:
+        """Count distinct predicted sequences in a metadata subset."""
+        return len({self._sequence_key(row) for _, row in metadata.iterrows()})
 
     def __getstate__(self) -> dict:
         """Exclude transient regressor state from pickle serialisation."""

--- a/winnow/calibration/features/retention_time.py
+++ b/winnow/calibration/features/retention_time.py
@@ -10,7 +10,7 @@ from sklearn.linear_model import LinearRegression
 
 from winnow.calibration.features.base import CalibrationFeatures, FeatureDependency
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.utils.peptide import tokens_to_proforma
+from winnow.utils.peptide import as_token_list, tokens_to_proforma
 
 
 class RetentionTimeFeature(CalibrationFeatures):
@@ -104,14 +104,14 @@ class RetentionTimeFeature(CalibrationFeatures):
     @staticmethod
     def _sequence_key(row: pd.Series) -> tuple:
         """Hashable key for a predicted peptide sequence."""
-        prediction = row["prediction"]
-        if isinstance(prediction, list):
-            return tuple(prediction)
+        tokens = as_token_list(row["prediction"])
+        if tokens is not None:
+            return tuple(tokens)
         if "prediction_untokenised" in row.index and pd.notna(
             row.get("prediction_untokenised")
         ):
             return (str(row["prediction_untokenised"]),)
-        return (str(prediction),)
+        return (str(row["prediction"]),)
 
     def check_valid_irt_prediction(self, dataset: CalibrationDataset) -> pd.Series:
         """Check which predictions are valid for iRT prediction.

--- a/winnow/calibration/features/retention_time.py
+++ b/winnow/calibration/features/retention_time.py
@@ -117,6 +117,7 @@ class RetentionTimeFeature(CalibrationFeatures):
         """Check which predictions are valid for iRT prediction.
 
         A prediction is considered invalid if any of the following conditions hold:
+        - The prediction is missing or not a non-empty token list (e.g. ``None``).
         - The predicted peptide sequence has more than ``max_peptide_length`` residue tokens.
         - The predicted peptide sequence contains a residue in ``unsupported_residues``.
 
@@ -128,13 +129,19 @@ class RetentionTimeFeature(CalibrationFeatures):
                 that the prediction satisfies all validity constraints and can be passed to
                 the Koina iRT model.
         """
-        filtered_dataset = dataset.filter_entries(
-            metadata_predicate=lambda row: (
-                len(row["prediction"]) > self.max_peptide_length
+        filtered_dataset = (
+            dataset.filter_entries(
+                metadata_predicate=lambda row: as_token_list(row["prediction"]) is None
             )
-        ).filter_entries(
-            metadata_predicate=lambda row: any(
-                token in row["prediction"] for token in self.unsupported_residues
+            .filter_entries(
+                metadata_predicate=lambda row: (
+                    len(row["prediction"]) > self.max_peptide_length
+                )
+            )
+            .filter_entries(
+                metadata_predicate=lambda row: any(
+                    token in row["prediction"] for token in self.unsupported_residues
+                )
             )
         )
 

--- a/winnow/configs/fdr_method/database_grounded.yaml
+++ b/winnow/configs/fdr_method/database_grounded.yaml
@@ -3,6 +3,4 @@
 _target_: winnow.fdr.database_grounded.DatabaseGroundedFDRControl
 
 confidence_feature: ${fdr_control.confidence_column}  # Name of the column with confidence scores to use for FDR estimation.
-residue_masses: ${residue_masses}  # The residue masses from global `residues` config
-isotope_error_range: [0, 1]  # The isotope error range for matching peptides
 drop: 10  # The number of top predictions to drop for stability

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -146,10 +146,10 @@ class CalibrationDataset:
         return CalibrationDataset(predictions=predictions, metadata=metadata)
 
     def save_metadata(self, path: Union[Path, str]) -> None:
-        """Save the dataset metadata to a CSV file.
+        """Save the dataset metadata to a CSV or parquet file.
 
         Args:
-            path (Union[Path, str]): Path to the output CSV file.
+            path (Union[Path, str]): Path to the output CSV or parquet file.
         """
         if isinstance(path, str):
             path = Path(path)
@@ -171,7 +171,13 @@ class CalibrationDataset:
             output_metadata = output_metadata.drop(columns=["valid_sequence"])
         if "valid_prediction" in output_metadata.columns:
             output_metadata = output_metadata.drop(columns=["valid_prediction"])
-        output_metadata.to_csv(path, index=False)
+
+        if path.suffix == ".csv":
+            output_metadata.to_csv(path, index=False)
+        elif path.suffix == ".parquet":
+            output_metadata.to_parquet(path)
+        else:
+            raise ValueError(f"Unsupported file extension: {path.suffix}")
 
     def save_predictions(self, path: Union[Path, str]) -> None:
         """Save the dataset predictions to a pickle file.

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 from winnow.compat.instanovo import ScoredSequence
 from winnow.utils.peptide import (
-    _is_missing_cell,
+    is_missing_cell,
     as_token_list,
     is_usable_peptide_label,
     is_valid_peptide_tokens,
@@ -38,7 +38,7 @@ def _normalise_and_validate_peptide_column(
 ) -> None:
     """Normalise empty containers to None and reject unsupported peptide cells."""
     for index, value in metadata[column].items():
-        if _is_missing_cell(value):
+        if is_missing_cell(value):
             continue
         if isinstance(value, str):
             raise ValueError(
@@ -84,7 +84,7 @@ class CalibrationDataset:
 
     Peptide columns must already be tokenised. ``__post_init__`` validates structure and
     derives ``valid_prediction`` / ``valid_sequence``; it does not parse ProForma strings
-    or compute ``correct`` / ``num_matches``.
+    or compute/validate ``correct`` / ``num_matches``.
 
     Attributes:
         metadata (pd.DataFrame): DataFrame containing metadata and predictions.

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -228,22 +228,7 @@ class CalibrationDataset:
             path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        output_metadata = self.metadata.copy(deep=True)
-
-        if "sequence" in output_metadata.columns:
-            output_metadata["sequence"] = output_metadata["sequence"].apply(
-                tokens_to_proforma
-            )
-        if "prediction" in output_metadata.columns:
-            output_metadata["prediction"] = output_metadata["prediction"].apply(
-                tokens_to_proforma
-            )
-        if "prediction_untokenised" in output_metadata.columns:
-            output_metadata = output_metadata.drop(columns=["prediction_untokenised"])
-        if "valid_sequence" in output_metadata.columns:
-            output_metadata = output_metadata.drop(columns=["valid_sequence"])
-        if "valid_prediction" in output_metadata.columns:
-            output_metadata = output_metadata.drop(columns=["valid_prediction"])
+        output_metadata = self.format_metadata_for_export()
 
         if path.suffix == ".csv":
             output_metadata.to_csv(path, index=False)
@@ -286,6 +271,33 @@ class CalibrationDataset:
             path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         self.metadata.to_parquet(path)
+
+    def format_metadata_for_export(self) -> pd.DataFrame:
+        """Return a copy of metadata formatted for CSV or parquet export.
+
+        Converts ``sequence`` and ``prediction`` token lists to ProForma strings and
+        drops internal columns (``prediction_untokenised``, ``valid_sequence``,
+        ``valid_prediction``). Does not modify the dataset in place.
+
+        Returns:
+            pd.DataFrame: Export-ready metadata copy.
+        """
+        output_metadata = self.metadata.copy(deep=True)
+        if "sequence" in output_metadata.columns:
+            output_metadata["sequence"] = output_metadata["sequence"].apply(
+                tokens_to_proforma
+            )
+        if "prediction" in output_metadata.columns:
+            output_metadata["prediction"] = output_metadata["prediction"].apply(
+                tokens_to_proforma
+            )
+        if "prediction_untokenised" in output_metadata.columns:
+            output_metadata = output_metadata.drop(columns=["prediction_untokenised"])
+        if "valid_sequence" in output_metadata.columns:
+            output_metadata = output_metadata.drop(columns=["valid_sequence"])
+        if "valid_prediction" in output_metadata.columns:
+            output_metadata = output_metadata.drop(columns=["valid_prediction"])
+        return output_metadata
 
     def _create_predicate_error_message(
         self, error: Exception, beam: Optional[List[ScoredSequence]], idx: int

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -11,12 +11,67 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 import pickle
+import warnings
 
 import numpy as np
 import pandas as pd
 
 from winnow.compat.instanovo import ScoredSequence
-from winnow.utils.peptide import tokens_to_proforma
+from winnow.utils.peptide import (
+    _is_missing_cell,
+    as_token_list,
+    is_usable_peptide_label,
+    is_valid_peptide_tokens,
+    tokens_to_proforma,
+)
+
+_LOADER_GUIDANCE = (
+    "Use a DatasetLoader to tokenise raw ProForma strings "
+    "(e.g. InstaNovoDatasetLoader) instead of constructing "
+    "CalibrationDataset directly."
+)
+
+
+def _normalise_and_validate_peptide_column(
+    metadata: pd.DataFrame,
+    column: str,
+) -> None:
+    """Normalise empty containers to None and reject unsupported peptide cells."""
+    for index, value in metadata[column].items():
+        if _is_missing_cell(value):
+            continue
+        if isinstance(value, str):
+            raise ValueError(
+                f"Peptide column {column!r} contains raw strings; "
+                f"expected token lists such as ['P', 'E', 'P']. {_LOADER_GUIDANCE}"
+            )
+        if as_token_list(value) is None:
+            if not is_usable_peptide_label(value):
+                metadata.at[index, column] = None
+                continue
+            raise ValueError(
+                f"Peptide column {column!r} contains an unsupported value of type "
+                f"{type(value).__name__!r}; expected a token list or None. "
+                f"{_LOADER_GUIDANCE}"
+            )
+
+
+def _derive_validity_column(
+    metadata: pd.DataFrame,
+    peptide_column: str,
+    validity_column: str,
+) -> None:
+    """Derive a structural validity flag, warning if a stale column is overwritten."""
+    derived = metadata[peptide_column].apply(is_valid_peptide_tokens)
+    if validity_column in metadata.columns:
+        existing = metadata[validity_column].fillna(False).astype(bool)
+        if not existing.equals(derived.astype(bool)):
+            warnings.warn(
+                f"Existing {validity_column!r} differs from token-structure "
+                "validation and will be overwritten.",
+                stacklevel=2,
+            )
+    metadata[validity_column] = derived
 
 
 @dataclass
@@ -26,6 +81,10 @@ class CalibrationDataset:
     It holds metadata and prediction results and provides various utility methods for filtering,
     saving, and evaluating data. For loading datasets from various file formats, see the
     concrete implementations of the DatasetLoader interface in the data_loaders package.
+
+    Peptide columns must already be tokenised. ``__post_init__`` validates structure and
+    derives ``valid_prediction`` / ``valid_sequence``; it does not parse ProForma strings
+    or compute ``correct`` / ``num_matches``.
 
     Attributes:
         metadata (pd.DataFrame): DataFrame containing metadata and predictions.
@@ -37,11 +96,25 @@ class CalibrationDataset:
     predictions: Optional[List[Optional[List[ScoredSequence]]]] = None
 
     def __post_init__(self):
-        """Validate that metadata and predictions have matching lengths."""
+        """Validate alignment and peptide column structure; derive ``valid_*`` flags."""
         # Allow predictions to be None (no beam predictions available)
         # But if predictions are provided, they must match metadata length
         if self.predictions is not None and len(self.metadata) != len(self.predictions):
             raise AssertionError("Length of metadata and predictions must match")
+
+        if "prediction" not in self.metadata.columns:
+            raise ValueError(
+                "CalibrationDataset requires a 'prediction' column containing "
+                "tokenised peptide predictions. If your inputs are raw peptide "
+                "strings, load them with a DatasetLoader first."
+            )
+
+        _normalise_and_validate_peptide_column(self.metadata, "prediction")
+        _derive_validity_column(self.metadata, "prediction", "valid_prediction")
+
+        if "sequence" in self.metadata.columns:
+            _normalise_and_validate_peptide_column(self.metadata, "sequence")
+            _derive_validity_column(self.metadata, "sequence", "valid_sequence")
 
     def save(self, data_dir: Path) -> None:
         """Save a `CalibrationDataset` to a directory.

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -100,7 +100,7 @@ class CalibrationDataset:
         # Allow predictions to be None (no beam predictions available)
         # But if predictions are provided, they must match metadata length
         if self.predictions is not None and len(self.metadata) != len(self.predictions):
-            raise AssertionError("Length of metadata and predictions must match")
+            raise ValueError("Length of metadata and predictions must match")
 
         if "prediction" not in self.metadata.columns:
             raise ValueError(

--- a/winnow/datasets/data_loaders/instanovo.py
+++ b/winnow/datasets/data_loaders/instanovo.py
@@ -166,7 +166,7 @@ class InstaNovoDatasetLoader(DatasetLoader):
             raise ValueError("predictions_path is required for InstaNovoDatasetLoader")
 
         inputs, has_labels = self._load_spectrum_data(data_path)
-        inputs = self._process_spectrum_data(inputs, has_labels)
+        inputs = inputs.to_pandas()
 
         # Load beam predictions only if beam_columns is configured
         if self.beam_columns:
@@ -180,7 +180,13 @@ class InstaNovoDatasetLoader(DatasetLoader):
             predictions_df.to_pandas(), inputs.columns
         )
         predictions = self._merge_spectrum_data(predictions, inputs)
-        predictions = self._evaluate_predictions(predictions, has_labels)
+        residue_remapping = self.metrics.residue_set.residue_remapping
+        predictions = utils.finalize_peptide_metadata(
+            predictions,
+            self.metrics,
+            has_labels=has_labels,
+            residue_remapping=residue_remapping,
+        )
 
         return CalibrationDataset(metadata=predictions, predictions=beams)
 
@@ -327,34 +333,6 @@ class InstaNovoDatasetLoader(DatasetLoader):
             for row in beam_df.iter_rows(named=True)
         ]
 
-    def _process_spectrum_data(
-        self, df: pl.DataFrame, has_labels: bool
-    ) -> pd.DataFrame:
-        """Processes the input data from the de novo sequencing model.
-
-        Args:
-            df (pl.DataFrame): The dataframe containing the spectrum data.
-            has_labels (bool): Whether the dataset has ground truth labels.
-
-        Returns:
-            pd.DataFrame: The processed dataframe.
-        """
-        # Convert to pandas for downstream compatibility
-        df = df.to_pandas()
-        if has_labels:
-            df["sequence"] = (
-                df["sequence"]
-                .apply(
-                    lambda peptide: (
-                        peptide.replace("L", "I")
-                        if isinstance(peptide, str)
-                        else peptide
-                    )
-                )
-                .apply(self.metrics._split_peptide)
-            )
-        return df
-
     def _process_predictions(
         self, preds_dataset: pd.DataFrame, input_dataset_columns: List[str]
     ) -> pd.DataFrame:
@@ -397,13 +375,6 @@ class InstaNovoDatasetLoader(DatasetLoader):
         preds_dataset["prediction"] = preds_dataset["prediction"].apply(
             lambda peptide: peptide.split(", ") if isinstance(peptide, str) else peptide
         )
-        preds_dataset["prediction"] = preds_dataset["prediction"].apply(
-            lambda peptide: (
-                ["I" if amino_acid == "L" else amino_acid for amino_acid in peptide]
-                if isinstance(peptide, list)
-                else peptide
-            )
-        )
 
         preds_dataset["prediction_untokenised"] = preds_dataset[
             "prediction_untokenised"
@@ -414,43 +385,3 @@ class InstaNovoDatasetLoader(DatasetLoader):
         )
 
         return preds_dataset
-
-    def _evaluate_predictions(
-        self, dataset: pd.DataFrame, has_labels: bool
-    ) -> pd.DataFrame:
-        """Evaluates predictions in a dataset by checking validity and accuracy.
-
-        Args:
-            dataset (pd.DataFrame): The dataframe containing the predictions.
-            has_labels (bool): Whether the dataset has ground truth labels.
-
-        Returns:
-            pd.DataFrame: The processed dataframe.
-        """
-        if has_labels:
-            dataset["valid_sequence"] = dataset["sequence"].apply(
-                lambda peptide: isinstance(peptide, list)
-            )
-        dataset["valid_prediction"] = dataset["prediction"].apply(
-            lambda peptide: isinstance(peptide, list)
-        )
-        if has_labels:
-            dataset["num_matches"] = dataset.apply(
-                lambda row: (
-                    self.metrics._novor_match(row["sequence"], row["prediction"])
-                    if isinstance(row["sequence"], list)
-                    and isinstance(row["prediction"], list)
-                    else 0
-                ),
-                axis=1,
-            )
-            dataset["correct"] = dataset.apply(
-                lambda row: (
-                    row["num_matches"] == len(row["sequence"]) == len(row["prediction"])
-                    if isinstance(row["sequence"], list)
-                    and isinstance(row["prediction"], list)
-                    else False
-                ),
-                axis=1,
-            )
-        return dataset

--- a/winnow/datasets/data_loaders/instanovo.py
+++ b/winnow/datasets/data_loaders/instanovo.py
@@ -304,9 +304,10 @@ class InstaNovoDatasetLoader(DatasetLoader):
                 )
 
                 if sequence and log_prob > float("-inf"):
+                    tokens = self.metrics._split_peptide(sequence)
                     scored_sequences.append(
                         ScoredSequence(
-                            sequence=self.metrics._split_peptide(sequence),
+                            sequence=utils._normalize_leucine_tokens(tokens),
                             mass_error=None,
                             sequence_log_probability=log_prob,
                             token_log_probabilities=ast.literal_eval(token_log_prob)
@@ -316,15 +317,6 @@ class InstaNovoDatasetLoader(DatasetLoader):
                     )
 
             return scored_sequences or None
-
-        # Apply L -> I transformation to multiple columns using polars with_columns
-        beam_df = beam_df.with_columns(
-            [
-                pl.col(col).str.replace_all("L", "I")
-                for col in beam_df.columns
-                if self.beam_columns["sequence"] in col
-            ]
-        )
 
         # Converts each row of the polars dataframe to a list of scored sequences representing the beam predictions for that row/spectrum.
         # All the beams are then stored in a list representing the entire dataset.
@@ -374,14 +366,6 @@ class InstaNovoDatasetLoader(DatasetLoader):
 
         preds_dataset["prediction"] = preds_dataset["prediction"].apply(
             lambda peptide: peptide.split(", ") if isinstance(peptide, str) else peptide
-        )
-
-        preds_dataset["prediction_untokenised"] = preds_dataset[
-            "prediction_untokenised"
-        ].apply(
-            lambda peptide: (
-                peptide.replace("L", "I") if isinstance(peptide, str) else peptide
-            )
         )
 
         return preds_dataset

--- a/winnow/datasets/data_loaders/instanovo.py
+++ b/winnow/datasets/data_loaders/instanovo.py
@@ -16,7 +16,7 @@ from instanovo.utils.residues import ResidueSet
 
 from winnow.compat.instanovo import ScoredSequence
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.datasets.data_loaders import utils
+from winnow.datasets.data_loaders import utils as data_utils
 from winnow.datasets.interfaces import DatasetLoader
 
 
@@ -29,8 +29,8 @@ class InstaNovoDatasetLoader(DatasetLoader):
         "log_probability": "log_probs",
     }
 
-    _df_from_matchms = staticmethod(utils.df_from_matchms)
-    _add_index_cols = staticmethod(utils.add_index_cols)
+    _df_from_matchms = staticmethod(data_utils.df_from_matchms)
+    _add_index_cols = staticmethod(data_utils.add_index_cols)
 
     def __init__(
         self,
@@ -181,7 +181,7 @@ class InstaNovoDatasetLoader(DatasetLoader):
         )
         predictions = self._merge_spectrum_data(predictions, inputs)
         residue_remapping = self.metrics.residue_set.residue_remapping
-        predictions = utils.finalize_peptide_metadata(
+        predictions = data_utils.finalize_peptide_metadata(
             predictions,
             self.metrics,
             has_labels=has_labels,
@@ -201,7 +201,7 @@ class InstaNovoDatasetLoader(DatasetLoader):
         Returns:
             Tuple[pl.DataFrame, bool]: A tuple containing the spectrum data and a boolean indicating whether the dataset has ground truth labels.
         """
-        return utils.load_spectrum_data(
+        return data_utils.load_spectrum_data(
             spectrum_path, add_index_cols=self.add_index_cols
         )
 
@@ -307,7 +307,7 @@ class InstaNovoDatasetLoader(DatasetLoader):
                     tokens = self.metrics._split_peptide(sequence)
                     scored_sequences.append(
                         ScoredSequence(
-                            sequence=utils._normalize_leucine_tokens(tokens),
+                            sequence=data_utils._normalize_leucine_tokens(tokens),
                             mass_error=None,
                             sequence_log_probability=log_prob,
                             token_log_probabilities=ast.literal_eval(token_log_prob)

--- a/winnow/datasets/data_loaders/mztab.py
+++ b/winnow/datasets/data_loaders/mztab.py
@@ -231,25 +231,6 @@ class MZTabDatasetLoader(DatasetLoader):
             )
 
     @staticmethod
-    def _as_aa_list(value: Any) -> Optional[list[str]]:
-        """Return amino-acid token lists from polars list cells."""
-        if isinstance(value, list):
-            return value
-        if isinstance(value, pl.Series):
-            return value.to_list()
-        return None
-
-    @staticmethod
-    def _normalize_leucine_tokens(tokens: list[str]) -> list[str]:
-        """Map leucine to isoleucine at the token level.
-
-        String-level ``L`` -> ``I`` replacement must not be applied before
-        tokenization because it corrupts modification names such as
-        ``Carbamidomethyl``.
-        """
-        return ["I" if token == "L" else token for token in tokens]
-
-    @staticmethod
     def _parse_spectra_ref(
         predictions: pl.DataFrame, experiment_name: str
     ) -> pl.DataFrame:
@@ -314,7 +295,7 @@ class MZTabDatasetLoader(DatasetLoader):
 
         experiment_name = Path(data_path).stem
         spectrum_data, has_labels = self._load_spectrum_data(data_path)
-        spectrum_data = self._process_spectrum_data(spectrum_data, has_labels)
+        spectrum_data = self._process_spectrum_data(spectrum_data)
 
         raw_predictions = self._load_dataset(predictions_path)
         is_casanovo = self._is_casanovo_mztab(raw_predictions)
@@ -327,18 +308,27 @@ class MZTabDatasetLoader(DatasetLoader):
             is_casanovo,
             experiment_name,
         )
-        predictions = self._tokenize(
-            predictions, "prediction_untokenised", "prediction"
+        predictions = predictions.with_columns(
+            pl.col("prediction_untokenised").alias("prediction")
+        )
+        residue_remapping = self.metrics.residue_set.residue_remapping
+        predictions = utils.finalize_peptide_metadata(
+            predictions,
+            self.metrics,
+            has_labels=False,
+            residue_remapping=residue_remapping,
         )
 
         top_predictions = self._get_top_predictions(predictions, is_casanovo)
         metadata = self._merge_data(spectrum_data, top_predictions)
-        metadata = self._evaluate_predictions(metadata, has_labels)
+        metadata = utils.finalize_peptide_metadata(
+            metadata,
+            self.metrics,
+            has_labels=has_labels,
+            residue_remapping=residue_remapping,
+        )
 
         metadata_pd = metadata.to_pandas()
-        metadata_pd["prediction"] = metadata_pd["prediction"].apply(
-            lambda x: x.tolist() if isinstance(x, np.ndarray) else x
-        )
 
         beam_predictions: Optional[List[Optional[List[ScoredSequence]]]] = None
         if is_casanovo and self.load_beams:
@@ -477,47 +467,8 @@ class MZTabDatasetLoader(DatasetLoader):
             beam_predictions.append(scored_sequences or None)
         return beam_predictions
 
-    def _tokenize(
-        self,
-        predictions: pl.DataFrame,
-        untokenised_column: str,
-        tokenised_column: str,
-    ) -> pl.DataFrame:
-        """Tokenize peptide strings and remap modifications to ProForma."""
-        return predictions.with_columns(
-            pl.col(untokenised_column)
-            .map_elements(self.metrics._split_peptide, return_dtype=pl.List(pl.Utf8))
-            .alias(tokenised_column)
-        ).with_columns(
-            pl.col(tokenised_column)
-            .map_elements(self._remap_tokens, return_dtype=pl.List(pl.Utf8))
-            .alias(tokenised_column)
-        )
-
-    def _remap_tokens(self, tokens: list[str]) -> list[str]:
-        """Remap Casanovo tokens to ProForma and normalise leucine.
-
-        Modification remapping runs after tokenization so ``residue_remapping``
-        keys match whole tokens (``M[Oxidation]``, ``[Acetyl]``, etc.). Leucine
-        normalisation is applied here rather than on raw peptide strings.
-        """
-        tokens = self._normalize_leucine_tokens(tokens)
-        return [
-            self.metrics.residue_set.residue_remapping.get(token, token)
-            for token in tokens
-        ]
-
-    def _process_spectrum_data(
-        self, spectrum_data: pl.DataFrame, has_labels: bool
-    ) -> pl.DataFrame:
-        """Tokenize ground-truth sequences when present."""
-        if has_labels:
-            spectrum_data = spectrum_data.with_columns(
-                pl.col("sequence").alias("sequence_untokenised")
-            )
-            spectrum_data = self._tokenize(
-                spectrum_data, "sequence_untokenised", "sequence"
-            )
+    def _process_spectrum_data(self, spectrum_data: pl.DataFrame) -> pl.DataFrame:
+        """Return spectrum data unchanged; tokenization happens in finalize."""
         return spectrum_data
 
     def _merge_data(
@@ -530,70 +481,3 @@ class MZTabDatasetLoader(DatasetLoader):
         return spectrum_data.join(predictions, on="spectrum_id", how="inner").sort(
             "index"
         )
-
-    def _novor_match_row(self, row: dict[str, Any]) -> int:
-        """Count AA matches for one labelled row via :meth:`Metrics._novor_match`.
-
-        Extracted from an inline polars ``map_elements`` lambda so sequence and
-        prediction are normalised to ``list[str]`` before matching, and so the
-        logic is typed/testable. Bound methods cannot be passed directly to
-        polars UDFs; call via ``lambda row: self._novor_match_row(row)``.
-        """
-        sequence = self._as_aa_list(row["sequence"])
-        prediction = self._as_aa_list(row["prediction"])
-        if sequence is None or prediction is None:
-            return 0
-        return self.metrics._novor_match(sequence, prediction)
-
-    def _prediction_is_correct(self, row: dict[str, Any]) -> bool:
-        """Return whether ``num_matches`` equals full peptide length for a row."""
-        sequence = self._as_aa_list(row["sequence"])
-        prediction = self._as_aa_list(row["prediction"])
-        if sequence is None or prediction is None:
-            return False
-        num_matches = row["num_matches"]
-        return num_matches == len(sequence) == len(prediction)
-
-    def _evaluate_predictions(
-        self, metadata: pl.DataFrame, has_labels: bool
-    ) -> pl.DataFrame:
-        """Annotate merged metadata with prediction validity and ground-truth matches."""
-        metadata = metadata.with_columns(
-            pl.col("prediction")
-            .map_elements(
-                lambda x: self._as_aa_list(x) is not None,
-                return_dtype=pl.Boolean,
-            )
-            .alias("valid_prediction"),
-        )
-
-        if not has_labels:
-            return metadata
-
-        metadata = (
-            metadata.with_columns(
-                pl.col("sequence")
-                .map_elements(
-                    lambda x: self._as_aa_list(x) is not None,
-                    return_dtype=pl.Boolean,
-                )
-                .alias("valid_sequence"),
-            )
-            .with_columns(
-                pl.struct(["sequence", "prediction"])
-                .map_elements(
-                    lambda row: self._novor_match_row(row),
-                    return_dtype=pl.Int64,
-                )
-                .alias("num_matches"),
-            )
-            .with_columns(
-                pl.struct(["sequence", "prediction", "num_matches"])
-                .map_elements(
-                    lambda row: self._prediction_is_correct(row),
-                    return_dtype=pl.Boolean,
-                )
-                .alias("correct")
-            )
-        )
-        return metadata

--- a/winnow/datasets/data_loaders/mztab.py
+++ b/winnow/datasets/data_loaders/mztab.py
@@ -449,6 +449,10 @@ class MZTabDatasetLoader(DatasetLoader):
             spectrum_preds = predictions.filter(pl.col("index") == spectrum_index)
             scored_sequences: List[ScoredSequence] = []
             for row in spectrum_preds.iter_rows(named=True):
+                # Skip blank/missing sequences
+                prediction = row["prediction"]
+                if not prediction:
+                    continue
                 token_scores = row["token_scores"]
                 token_log_probs = None
                 if token_scores is not None:
@@ -458,7 +462,7 @@ class MZTabDatasetLoader(DatasetLoader):
                     ]
                 scored_sequences.append(
                     ScoredSequence(
-                        sequence=row["prediction"],
+                        sequence=prediction,
                         mass_error=None,
                         sequence_log_probability=self._casanovo_raw_score_to_log_probability(
                             float(row["confidence"])

--- a/winnow/datasets/data_loaders/mztab.py
+++ b/winnow/datasets/data_loaders/mztab.py
@@ -44,7 +44,7 @@ from pyteomics import mztab
 
 from winnow.compat.instanovo import ScoredSequence
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.datasets.data_loaders import utils
+from winnow.datasets.data_loaders import utils as data_utils
 from winnow.datasets.interfaces import DatasetLoader
 
 
@@ -312,7 +312,7 @@ class MZTabDatasetLoader(DatasetLoader):
             pl.col("prediction_untokenised").alias("prediction")
         )
         residue_remapping = self.metrics.residue_set.residue_remapping
-        predictions = utils.finalize_peptide_metadata(
+        predictions = data_utils.finalize_peptide_metadata(
             predictions,
             self.metrics,
             has_labels=False,
@@ -321,7 +321,7 @@ class MZTabDatasetLoader(DatasetLoader):
 
         top_predictions = self._get_top_predictions(predictions, is_casanovo)
         metadata = self._merge_data(spectrum_data, top_predictions)
-        metadata = utils.finalize_peptide_metadata(
+        metadata = data_utils.finalize_peptide_metadata(
             metadata,
             self.metrics,
             has_labels=has_labels,
@@ -351,8 +351,10 @@ class MZTabDatasetLoader(DatasetLoader):
             Tuple of (DataFrame containing spectrum data, whether ground truth labels exist).
         """
         spectrum_path = Path(spectrum_path)
-        df, has_labels = utils.load_spectrum_data(spectrum_path, add_index_cols=False)
-        df = utils.add_row_order_spectrum_ids(df, spectrum_path.stem)
+        df, has_labels = data_utils.load_spectrum_data(
+            spectrum_path, add_index_cols=False
+        )
+        df = data_utils.add_row_order_spectrum_ids(df, spectrum_path.stem)
         return df, has_labels
 
     def _process_predictions(

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -1,14 +1,19 @@
-"""Shared spectrum file I/O for dataset loaders (Parquet, IPC, MGF)."""
+"""Shared spectrum file I/O and peptide normalization for dataset loaders."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any, Tuple, Union
 
+import numpy as np
 import polars as pl
+import pandas as pd
+from instanovo.utils.metrics import Metrics
 
 if TYPE_CHECKING:
     from matchms import Spectrum
+
+DataFrameT = Union[pd.DataFrame, pl.DataFrame]
 
 
 def df_from_matchms(spectra: list[Spectrum]) -> pl.DataFrame:
@@ -111,6 +116,423 @@ def add_index_cols(df: pl.DataFrame, fp: Path | str) -> pl.DataFrame:
 _add_index_cols_fn = add_index_cols
 
 
+def _is_missing_cell(value: object) -> bool:
+    """Return True when a peptide cell is absent (None, NaN, pd.NA)."""
+    if value is None:
+        return True
+    if isinstance(value, float) and value != value:
+        return True
+    try:
+        if pd.isna(value):
+            return True
+    except (TypeError, ValueError):
+        pass
+    return False
+
+
+def is_usable_peptide_label(value: object) -> bool:
+    """Return True when a raw peptide cell contains a label or sequence string."""
+    if _is_missing_cell(value):
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (list, tuple)):
+        return len(value) > 0
+    if isinstance(value, pl.Series):
+        return len(value) > 0
+    if isinstance(value, np.ndarray):
+        return value.size > 0
+    if hasattr(value, "tolist"):
+        tokens = value.tolist()
+        return isinstance(tokens, (list, tuple)) and len(tokens) > 0
+    return True
+
+
+def as_token_list(value: object) -> list[str] | None:
+    """Coerce a metadata cell to a non-empty AA token list, or ``None``.
+
+    Accepts container types that already hold token strings. Does not parse raw
+    peptide strings; use :func:`normalize_peptide_cell` for that.
+    """
+    if _is_missing_cell(value):
+        return None
+    if isinstance(value, pl.Series):
+        tokens = value.to_list()
+        return list(tokens) if tokens else None
+    if isinstance(value, (list, tuple)):
+        tokens = list(value)
+        return tokens if tokens else None
+    if isinstance(value, np.ndarray):
+        tokens = value.tolist()
+        return tokens if isinstance(tokens, list) and tokens else None
+    return None
+
+
+def is_valid_peptide_tokens(value: object) -> bool:
+    """Return True when a cell holds a non-empty token list (not a raw string)."""
+    return as_token_list(value) is not None
+
+
+def _normalize_leucine_tokens(tokens: list[str]) -> list[str]:
+    """Map leucine to isoleucine at the token level."""
+    return ["I" if token == "L" else token for token in tokens]
+
+
+def _apply_token_postprocessing(
+    tokens: list[str],
+    *,
+    residue_remapping: dict[str, str],
+    normalize_leucine: bool = True,
+) -> list[str]:
+    if normalize_leucine:
+        tokens = _normalize_leucine_tokens(tokens)
+    return [residue_remapping.get(token, token) for token in tokens]
+
+
+def normalize_peptide_cell(
+    value: object,
+    metrics: Metrics,
+    *,
+    residue_remapping: dict[str, str],
+    normalize_leucine: bool = True,
+    require_label: bool = False,
+) -> list[str] | None:
+    """Normalize one peptide cell to ProForma token list, or ``None`` if absent/empty.
+
+    Args:
+        value: Raw or tokenized cell from pandas or polars.
+        metrics: InstaNovo metrics for string tokenization.
+        residue_remapping: Modification token remapping table.
+        normalize_leucine: When True, map ``L`` → ``I`` at token level.
+        require_label: When True, return ``None`` for cells that fail
+            :func:`is_usable_peptide_label` before tokenization (ground truth).
+    """
+    if require_label and not is_usable_peptide_label(value):
+        return None
+    if _is_missing_cell(value):
+        return None
+    if isinstance(value, str):
+        if value.strip() == "":
+            return None
+        peptide = value.replace("L", "I") if normalize_leucine else value
+        tokens = metrics._split_peptide(peptide)
+    else:
+        tokens = as_token_list(value)
+        if tokens is None:
+            return None
+    tokens = _apply_token_postprocessing(
+        tokens,
+        residue_remapping=residue_remapping,
+        normalize_leucine=normalize_leucine,
+    )
+    return tokens if tokens else None
+
+
+def _normalize_peptide_column_pandas(
+    series: pd.Series,
+    metrics: Metrics,
+    *,
+    residue_remapping: dict[str, str],
+    require_label: bool,
+) -> pd.Series:
+    return series.apply(
+        lambda value: normalize_peptide_cell(
+            value,
+            metrics,
+            residue_remapping=residue_remapping,
+            require_label=require_label,
+        )
+    )
+
+
+def _normalize_peptide_column_polars(
+    series: pl.Series,
+    metrics: Metrics,
+    *,
+    residue_remapping: dict[str, str],
+    require_label: bool,
+) -> pl.Series:
+    return series.map_elements(
+        lambda value: normalize_peptide_cell(
+            value,
+            metrics,
+            residue_remapping=residue_remapping,
+            require_label=require_label,
+        ),
+        return_dtype=pl.List(pl.Utf8),
+    )
+
+
+def _row_evaluation_pandas(
+    row: pd.Series,
+    metrics: Metrics,
+    *,
+    sequence_col: str,
+    prediction_col: str,
+) -> tuple[int, bool]:
+    sequence = as_token_list(row.get(sequence_col)) or []
+    prediction = as_token_list(row.get(prediction_col)) or []
+    sequence_valid = is_valid_peptide_tokens(row.get(sequence_col))
+    prediction_valid = is_valid_peptide_tokens(row.get(prediction_col))
+    num_matches = row_num_matches(
+        sequence,
+        prediction,
+        metrics,
+        sequence_valid=sequence_valid,
+        prediction_valid=prediction_valid,
+    )
+    correct = row_is_correct(
+        num_matches,
+        sequence,
+        prediction,
+        sequence_valid=sequence_valid,
+        prediction_valid=prediction_valid,
+    )
+    return num_matches, correct
+
+
+def _row_evaluation_polars(
+    row: dict[str, Any],
+    metrics: Metrics,
+    *,
+    sequence_col: str,
+    prediction_col: str,
+) -> tuple[int, bool]:
+    sequence = as_token_list(row.get(sequence_col)) or []
+    prediction = as_token_list(row.get(prediction_col)) or []
+    sequence_valid = is_valid_peptide_tokens(row.get(sequence_col))
+    prediction_valid = is_valid_peptide_tokens(row.get(prediction_col))
+    num_matches = row_num_matches(
+        sequence,
+        prediction,
+        metrics,
+        sequence_valid=sequence_valid,
+        prediction_valid=prediction_valid,
+    )
+    correct = row_is_correct(
+        num_matches,
+        sequence,
+        prediction,
+        sequence_valid=sequence_valid,
+        prediction_valid=prediction_valid,
+    )
+    return num_matches, correct
+
+
+def _finalize_peptide_metadata_pandas(
+    metadata: pd.DataFrame,
+    metrics: Metrics,
+    *,
+    has_labels: bool,
+    residue_remapping: dict[str, str],
+    sequence_col: str,
+    prediction_col: str,
+) -> pd.DataFrame:
+    metadata[prediction_col] = _normalize_peptide_column_pandas(
+        metadata[prediction_col],
+        metrics,
+        residue_remapping=residue_remapping,
+        require_label=False,
+    )
+    metadata["valid_prediction"] = metadata[prediction_col].apply(
+        is_valid_peptide_tokens
+    )
+
+    if not has_labels:
+        return metadata
+
+    metadata[sequence_col] = _normalize_peptide_column_pandas(
+        metadata[sequence_col],
+        metrics,
+        residue_remapping=residue_remapping,
+        require_label=True,
+    )
+    metadata["valid_sequence"] = metadata[sequence_col].apply(is_valid_peptide_tokens)
+
+    num_matches: list[int] = []
+    correct: list[bool] = []
+    for _, row in metadata.iterrows():
+        nm, ok = _row_evaluation_pandas(
+            row,
+            metrics,
+            sequence_col=sequence_col,
+            prediction_col=prediction_col,
+        )
+        num_matches.append(nm)
+        correct.append(ok)
+    metadata["num_matches"] = num_matches
+    metadata["correct"] = correct
+    return metadata
+
+
+def _finalize_peptide_metadata_polars(
+    metadata: pl.DataFrame,
+    metrics: Metrics,
+    *,
+    has_labels: bool,
+    residue_remapping: dict[str, str],
+    sequence_col: str,
+    prediction_col: str,
+) -> pl.DataFrame:
+    metadata = metadata.with_columns(
+        _normalize_peptide_column_polars(
+            metadata.get_column(prediction_col),
+            metrics,
+            residue_remapping=residue_remapping,
+            require_label=False,
+        ).alias(prediction_col),
+    ).with_columns(
+        pl.col(prediction_col)
+        .map_elements(is_valid_peptide_tokens, return_dtype=pl.Boolean)
+        .alias("valid_prediction"),
+    )
+
+    if not has_labels:
+        return metadata
+
+    metadata = metadata.with_columns(
+        _normalize_peptide_column_polars(
+            metadata.get_column(sequence_col),
+            metrics,
+            residue_remapping=residue_remapping,
+            require_label=True,
+        ).alias(sequence_col),
+    ).with_columns(
+        pl.col(sequence_col)
+        .map_elements(is_valid_peptide_tokens, return_dtype=pl.Boolean)
+        .fill_null(False)
+        .alias("valid_sequence"),
+    )
+
+    metadata = metadata.with_columns(
+        pl.struct([sequence_col, prediction_col])
+        .map_elements(
+            lambda row: _row_evaluation_polars(
+                row,
+                metrics,
+                sequence_col=sequence_col,
+                prediction_col=prediction_col,
+            )[0],
+            return_dtype=pl.Int64,
+        )
+        .alias("num_matches"),
+    ).with_columns(
+        pl.struct([sequence_col, prediction_col])
+        .map_elements(
+            lambda row: _row_evaluation_polars(
+                row,
+                metrics,
+                sequence_col=sequence_col,
+                prediction_col=prediction_col,
+            )[1],
+            return_dtype=pl.Boolean,
+        )
+        .alias("correct"),
+    )
+    return metadata
+
+
+def finalize_peptide_metadata(
+    metadata: DataFrameT,
+    metrics: Metrics,
+    *,
+    has_labels: bool,
+    residue_remapping: dict[str, str] | None = None,
+    sequence_col: str = "sequence",
+    prediction_col: str = "prediction",
+) -> DataFrameT:
+    """Normalize peptide columns, set validity flags, and compute match columns.
+
+    Accepts pandas or polars frames and returns the same frame type. All logic
+    delegates to cell-level helpers so behaviour is identical regardless of
+    whether cells arrive as ``list``, ``np.ndarray``, ``pl.Series``, or ``str``.
+    """
+    if residue_remapping is None:
+        residue_remapping = metrics.residue_set.residue_remapping
+
+    if isinstance(metadata, pl.DataFrame):
+        return _finalize_peptide_metadata_polars(
+            metadata,
+            metrics,
+            has_labels=has_labels,
+            residue_remapping=residue_remapping,
+            sequence_col=sequence_col,
+            prediction_col=prediction_col,
+        )
+    return _finalize_peptide_metadata_pandas(
+        metadata,
+        metrics,
+        has_labels=has_labels,
+        residue_remapping=residue_remapping,
+        sequence_col=sequence_col,
+        prediction_col=prediction_col,
+    )
+
+
+def _ensure_valid_sequence_column(metadata: pd.DataFrame) -> None:
+    """Set ``valid_sequence`` from ``sequence`` when the column is absent."""
+    if "sequence" in metadata.columns and "valid_sequence" not in metadata.columns:
+        metadata["valid_sequence"] = metadata["sequence"].apply(is_valid_peptide_tokens)
+
+
+def labelled_training_mask(metadata: pd.DataFrame) -> np.ndarray:
+    """Return a boolean mask of rows eligible for supervised training or FDR fit.
+
+    When a ``sequence`` column is present, ``valid_sequence`` is derived from it
+    if not already supplied. When neither column exists (e.g. precomputed labels
+    only), all rows are included.
+    """
+    if "sequence" in metadata.columns:
+        _ensure_valid_sequence_column(metadata)
+        return metadata["valid_sequence"].fillna(False).to_numpy(dtype=bool)
+    return np.ones(len(metadata), dtype=bool)
+
+
+def require_labelled_rows(metadata: pd.DataFrame, *, context: str) -> np.ndarray:
+    """Return ``labelled_training_mask`` or raise when no rows are eligible."""
+    mask = labelled_training_mask(metadata)
+    if not mask.any():
+        raise ValueError(
+            f"{context} requires at least one row with valid_sequence=True."
+        )
+    return mask
+
+
+def row_num_matches(
+    sequence: list[str],
+    prediction: list[str],
+    metrics: Metrics,
+    *,
+    sequence_valid: bool,
+    prediction_valid: bool,
+) -> int:
+    """Count residue matches between tokenized sequence and prediction."""
+    if not sequence_valid or not prediction_valid or not sequence or not prediction:
+        return 0
+    return metrics._novor_match(sequence, prediction)
+
+
+def row_is_correct(
+    num_matches: int,
+    sequence: list[str],
+    prediction: list[str],
+    *,
+    sequence_valid: bool,
+    prediction_valid: bool,
+) -> bool:
+    """Return True when prediction is a full-length exact match to sequence."""
+    if not sequence_valid or not prediction_valid:
+        return False
+    return num_matches == len(sequence) == len(prediction)
+
+
+def has_ground_truth_sequence_labels(df: pl.DataFrame) -> bool:
+    """Return True when ``sequence`` contains at least one non-empty label."""
+    if "sequence" not in df.columns:
+        return False
+    return any(is_usable_peptide_label(value) for value in df["sequence"])
+
+
 def load_spectrum_data(
     spectrum_path: Path | str, *, add_index_cols: bool = False
 ) -> Tuple[pl.DataFrame, bool]:
@@ -144,4 +566,8 @@ def load_spectrum_data(
     if spectrum_path.suffix == ".mgf" or add_index_cols:
         df = _add_index_cols_fn(df, spectrum_path)
 
-    return df, "sequence" in df.columns
+    has_labels = has_ground_truth_sequence_labels(df)
+    if "sequence" in df.columns and not has_labels:
+        df = df.drop("sequence")
+
+    return df, has_labels

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -420,7 +420,7 @@ def finalize_peptide_metadata(
 def labelled_training_mask(metadata: pd.DataFrame) -> np.ndarray:
     """Return a boolean mask of rows eligible for supervised training or FDR fit.
 
-    When a ``sequence`` column is present, ``valid_sequence`` must already be
+    When a ``sequence`` column is present, ``valid_sequence`` and ``correct`` must already be
     finalised (e.g. by ``CalibrationDataset.__post_init__`` or a DatasetLoader).
     When neither column exists (e.g. precomputed labels only), all rows are
     included.
@@ -430,6 +430,12 @@ def labelled_training_mask(metadata: pd.DataFrame) -> np.ndarray:
             raise ValueError(
                 "Metadata with a 'sequence' column requires a finalised "
                 "'valid_sequence' column. Load data through a DatasetLoader or "
+                "construct a CalibrationDataset instead of passing raw metadata."
+            )
+        if "correct" not in metadata.columns:
+            raise ValueError(
+                "Metadata with a 'sequence' column requires a finalised "
+                "'correct' column. Load data through a DatasetLoader or "
                 "construct a CalibrationDataset instead of passing raw metadata."
             )
         return metadata["valid_sequence"].fillna(False).to_numpy(dtype=bool)

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -11,7 +11,7 @@ import pandas as pd
 from instanovo.utils.metrics import Metrics
 
 from winnow.utils.peptide import (
-    _is_missing_cell,
+    is_missing_cell,
     as_token_list,
     is_usable_peptide_label,
     is_valid_peptide_tokens,
@@ -159,7 +159,7 @@ def normalize_peptide_cell(
     """
     if require_label and not is_usable_peptide_label(value):
         return None
-    if _is_missing_cell(value):
+    if is_missing_cell(value):
         return None
     if isinstance(value, str):
         if value.strip() == "":

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -164,8 +164,7 @@ def normalize_peptide_cell(
     if isinstance(value, str):
         if value.strip() == "":
             return None
-        peptide = value.replace("L", "I") if normalize_leucine else value
-        tokens = metrics._split_peptide(peptide)
+        tokens = metrics._split_peptide(value)
     else:
         tokens = as_token_list(value)
         if tokens is None:

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -407,28 +407,26 @@ def _finalize_peptide_metadata_polars(
     metadata = metadata.with_columns(
         pl.struct([sequence_col, prediction_col])
         .map_elements(
-            lambda row: _row_evaluation_polars(
-                row,
-                metrics,
-                sequence_col=sequence_col,
-                prediction_col=prediction_col,
-            )[0],
-            return_dtype=pl.Int64,
+            lambda row: dict(
+                zip(
+                    ("num_matches", "correct"),
+                    _row_evaluation_polars(
+                        row,
+                        metrics,
+                        sequence_col=sequence_col,
+                        prediction_col=prediction_col,
+                    ),
+                )
+            ),
+            return_dtype=pl.Struct(
+                [
+                    pl.Field("num_matches", pl.Int64),
+                    pl.Field("correct", pl.Boolean),
+                ]
+            ),
         )
-        .alias("num_matches"),
-    ).with_columns(
-        pl.struct([sequence_col, prediction_col])
-        .map_elements(
-            lambda row: _row_evaluation_polars(
-                row,
-                metrics,
-                sequence_col=sequence_col,
-                prediction_col=prediction_col,
-            )[1],
-            return_dtype=pl.Boolean,
-        )
-        .alias("correct"),
-    )
+        .alias("_row_eval")
+    ).unnest("_row_eval")
     return metadata
 
 

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -10,6 +10,13 @@ import polars as pl
 import pandas as pd
 from instanovo.utils.metrics import Metrics
 
+from winnow.utils.peptide import (
+    _is_missing_cell,
+    as_token_list,
+    is_usable_peptide_label,
+    is_valid_peptide_tokens,
+)
+
 if TYPE_CHECKING:
     from matchms import Spectrum
 
@@ -114,63 +121,6 @@ def add_index_cols(df: pl.DataFrame, fp: Path | str) -> pl.DataFrame:
 
 
 _add_index_cols_fn = add_index_cols
-
-
-def _is_missing_cell(value: object) -> bool:
-    """Return True when a peptide cell is absent (None, NaN, pd.NA)."""
-    if value is None:
-        return True
-    if isinstance(value, float) and value != value:
-        return True
-    try:
-        if pd.isna(value):
-            return True
-    except (TypeError, ValueError):
-        pass
-    return False
-
-
-def is_usable_peptide_label(value: object) -> bool:
-    """Return True when a raw peptide cell contains a label or sequence string."""
-    if _is_missing_cell(value):
-        return False
-    if isinstance(value, str):
-        return value.strip() != ""
-    if isinstance(value, (list, tuple)):
-        return len(value) > 0
-    if isinstance(value, pl.Series):
-        return len(value) > 0
-    if isinstance(value, np.ndarray):
-        return value.size > 0
-    if hasattr(value, "tolist"):
-        tokens = value.tolist()
-        return isinstance(tokens, (list, tuple)) and len(tokens) > 0
-    return True
-
-
-def as_token_list(value: object) -> list[str] | None:
-    """Coerce a metadata cell to a non-empty AA token list, or ``None``.
-
-    Accepts container types that already hold token strings. Does not parse raw
-    peptide strings; use :func:`normalize_peptide_cell` for that.
-    """
-    if _is_missing_cell(value):
-        return None
-    if isinstance(value, pl.Series):
-        tokens = value.to_list()
-        return list(tokens) if tokens else None
-    if isinstance(value, (list, tuple)):
-        tokens = list(value)
-        return tokens if tokens else None
-    if isinstance(value, np.ndarray):
-        tokens = value.tolist()
-        return tokens if isinstance(tokens, list) and tokens else None
-    return None
-
-
-def is_valid_peptide_tokens(value: object) -> bool:
-    """Return True when a cell holds a non-empty token list (not a raw string)."""
-    return as_token_list(value) is not None
 
 
 def _normalize_leucine_tokens(tokens: list[str]) -> list[str]:
@@ -469,21 +419,21 @@ def finalize_peptide_metadata(
     )
 
 
-def _ensure_valid_sequence_column(metadata: pd.DataFrame) -> None:
-    """Set ``valid_sequence`` from ``sequence`` when the column is absent."""
-    if "sequence" in metadata.columns and "valid_sequence" not in metadata.columns:
-        metadata["valid_sequence"] = metadata["sequence"].apply(is_valid_peptide_tokens)
-
-
 def labelled_training_mask(metadata: pd.DataFrame) -> np.ndarray:
     """Return a boolean mask of rows eligible for supervised training or FDR fit.
 
-    When a ``sequence`` column is present, ``valid_sequence`` is derived from it
-    if not already supplied. When neither column exists (e.g. precomputed labels
-    only), all rows are included.
+    When a ``sequence`` column is present, ``valid_sequence`` must already be
+    finalised (e.g. by ``CalibrationDataset.__post_init__`` or a DatasetLoader).
+    When neither column exists (e.g. precomputed labels only), all rows are
+    included.
     """
     if "sequence" in metadata.columns:
-        _ensure_valid_sequence_column(metadata)
+        if "valid_sequence" not in metadata.columns:
+            raise ValueError(
+                "Metadata with a 'sequence' column requires a finalised "
+                "'valid_sequence' column. Load data through a DatasetLoader or "
+                "construct a CalibrationDataset instead of passing raw metadata."
+            )
         return metadata["valid_sequence"].fillna(False).to_numpy(dtype=bool)
     return np.ones(len(metadata), dtype=bool)
 

--- a/winnow/datasets/data_loaders/winnow.py
+++ b/winnow/datasets/data_loaders/winnow.py
@@ -13,6 +13,7 @@ from instanovo.utils.metrics import Metrics
 from instanovo.utils.residues import ResidueSet
 
 from winnow.datasets.calibration_dataset import CalibrationDataset
+from winnow.datasets.data_loaders import utils
 from winnow.datasets.interfaces import DatasetLoader
 
 
@@ -82,6 +83,15 @@ class WinnowDatasetLoader(DatasetLoader):
                 )
             )
         )
+
+        if "valid_prediction" not in metadata.columns:
+            metadata["valid_prediction"] = metadata["prediction"].apply(
+                utils.is_valid_peptide_tokens
+            )
+        if "sequence" in metadata.columns and "valid_sequence" not in metadata.columns:
+            metadata["valid_sequence"] = metadata["sequence"].apply(
+                utils.is_valid_peptide_tokens
+            )
 
         predictions_pkl_path = data_path / Path("predictions.pkl")
         if predictions_pkl_path.exists():

--- a/winnow/datasets/data_loaders/winnow.py
+++ b/winnow/datasets/data_loaders/winnow.py
@@ -58,13 +58,8 @@ class WinnowDatasetLoader(DatasetLoader):
                 f"The file should be a valid CSV containing PSM metadata. Error: {e}"
             ) from e
 
-        if "sequence" in metadata.columns:
-            metadata["sequence"] = metadata["sequence"].apply(
-                self.metrics._split_peptide
-            )
-        metadata["prediction"] = metadata["prediction"].apply(
-            self.metrics._split_peptide
-        )
+        # Reload-specific array parsing for saved CSV serialisations. Preserve both
+        # comma-delimited lists and numpy print formats.
         metadata["mz_array"] = metadata["mz_array"].apply(
             lambda s: (
                 ast.literal_eval(s)
@@ -84,14 +79,18 @@ class WinnowDatasetLoader(DatasetLoader):
             )
         )
 
-        if "valid_prediction" not in metadata.columns:
-            metadata["valid_prediction"] = metadata["prediction"].apply(
-                utils.is_valid_peptide_tokens
-            )
-        if "sequence" in metadata.columns and "valid_sequence" not in metadata.columns:
-            metadata["valid_sequence"] = metadata["sequence"].apply(
-                utils.is_valid_peptide_tokens
-            )
+        has_labels = "sequence" in metadata.columns and any(
+            utils.is_usable_peptide_label(value) for value in metadata["sequence"]
+        )
+        if "sequence" in metadata.columns and not has_labels:
+            metadata = metadata.drop(columns=["sequence"])
+
+        metadata = utils.finalize_peptide_metadata(
+            metadata,
+            self.metrics,
+            has_labels=has_labels,
+            residue_remapping=self.metrics.residue_set.residue_remapping,
+        )
 
         predictions_pkl_path = data_path / Path("predictions.pkl")
         if predictions_pkl_path.exists():

--- a/winnow/datasets/data_loaders/winnow.py
+++ b/winnow/datasets/data_loaders/winnow.py
@@ -13,7 +13,7 @@ from instanovo.utils.metrics import Metrics
 from instanovo.utils.residues import ResidueSet
 
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.datasets.data_loaders import utils
+from winnow.datasets.data_loaders import utils as data_utils
 from winnow.datasets.interfaces import DatasetLoader
 
 
@@ -80,12 +80,12 @@ class WinnowDatasetLoader(DatasetLoader):
         )
 
         has_labels = "sequence" in metadata.columns and any(
-            utils.is_usable_peptide_label(value) for value in metadata["sequence"]
+            data_utils.is_usable_peptide_label(value) for value in metadata["sequence"]
         )
         if "sequence" in metadata.columns and not has_labels:
             metadata = metadata.drop(columns=["sequence"])
 
-        metadata = utils.finalize_peptide_metadata(
+        metadata = data_utils.finalize_peptide_metadata(
             metadata,
             self.metrics,
             has_labels=has_labels,

--- a/winnow/fdr/base.py
+++ b/winnow/fdr/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABCMeta
 from abc import abstractmethod
-from typing import Iterable, Tuple, TypeVar
+from typing import Generic, Tuple, TypeVar
 import warnings
 
 import numpy as np
@@ -12,10 +12,10 @@ from numpy.typing import NDArray
 
 from winnow.datasets.psm_dataset import PSMDataset
 
-T = TypeVar("T", bound=Iterable)
+T = TypeVar("T")
 
 
-class FDRControl(metaclass=ABCMeta):
+class FDRControl(Generic[T], metaclass=ABCMeta):
     """The interface for FDR control classes."""
 
     def __init__(self) -> None:

--- a/winnow/fdr/database_grounded.py
+++ b/winnow/fdr/database_grounded.py
@@ -1,9 +1,14 @@
 from typing import Tuple
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 from instanovo.utils.metrics import Metrics
 from instanovo.utils.residues import ResidueSet
 
+from winnow.datasets.data_loaders.utils import (
+    finalize_peptide_metadata,
+    require_labelled_rows,
+)
 from winnow.fdr.base import FDRControl
 
 
@@ -37,39 +42,30 @@ class DatabaseGroundedFDRControl(FDRControl):
     ) -> None:
         """Computes the precision-recall curve by comparing model predictions to database-grounded peptide sequences.
 
+        Per-row correctness is derived from ``sequence`` vs ``prediction``. Rows with
+        ``valid_sequence=False`` receive ``correct=False`` but are excluded from the
+        FDR curve.
+
         Args:
-            dataset (pd.DataFrame):
-                A DataFrame containing the following columns:
-                - 'sequence': Ground-truth peptide sequences.
-                - 'prediction': Model-predicted peptide sequences.
-                - Confidence column`confidence_feature` specified in the DatabaseGroundedFDRControl constructor.
+            dataset: DataFrame with ``sequence``, ``prediction``, and the confidence
+                column named by ``confidence_feature``.
         """
         assert len(dataset) > 0, "Fit method requires non-empty data"
 
-        if isinstance(dataset["sequence"].iloc[0], str):
-            dataset["sequence"] = dataset["sequence"].apply(self.metrics._split_peptide)
-        if isinstance(dataset["prediction"].iloc[0], str):
-            dataset["prediction"] = dataset["prediction"].apply(
-                self.metrics._split_peptide
-            )
-
-        dataset["num_matches"] = dataset.apply(
-            lambda row: self.metrics._novor_match(row["sequence"], row["prediction"]),
-            axis=1,
-        )
-        dataset["correct"] = dataset.apply(
-            lambda row: (
-                row["num_matches"] == len(row["sequence"]) == len(row["prediction"])
-            ),
-            axis=1,
+        finalize_peptide_metadata(
+            dataset,
+            self.metrics,
+            has_labels=True,
         )
         self.preds = dataset[["correct", self.confidence_feature]]
 
-        dataset = dataset.sort_values(
-            by=self.confidence_feature, axis=0, ascending=False
+        mask = require_labelled_rows(dataset, context="Database-grounded FDR fit")
+        labelled = dataset.loc[mask].sort_values(
+            by=self.confidence_feature, ascending=False
         )
-        precision = np.cumsum(dataset["correct"]) / np.arange(1, len(dataset) + 1)
-        confidence = np.array(dataset[self.confidence_feature])
+
+        precision = np.cumsum(labelled["correct"]) / np.arange(1, len(labelled) + 1)
+        confidence = np.array(labelled[self.confidence_feature])
 
         self._fdr_values = np.array(1 - precision[self.drop :])
         self._confidence_scores = confidence[self.drop :]

--- a/winnow/fdr/database_grounded.py
+++ b/winnow/fdr/database_grounded.py
@@ -34,7 +34,8 @@ class DatabaseGroundedFDRControl(FDRControl[CalibrationDataset]):
         Raises:
             ValueError: If required finalised label columns are missing.
         """
-        assert len(dataset) > 0, "Fit method requires non-empty data"
+        if len(dataset) == 0:
+            raise ValueError("Fit method requires non-empty data")
 
         metadata = dataset.metadata
         missing = [

--- a/winnow/fdr/database_grounded.py
+++ b/winnow/fdr/database_grounded.py
@@ -44,7 +44,7 @@ class DatabaseGroundedFDRControl(FDRControl):
 
         Per-row correctness is derived from ``sequence`` vs ``prediction``. Rows with
         ``valid_sequence=False`` receive ``correct=False`` but are excluded from the
-        FDR curve.
+        FDR curve and from ``self.preds``.
 
         Args:
             dataset: DataFrame with ``sequence``, ``prediction``, and the confidence
@@ -57,12 +57,12 @@ class DatabaseGroundedFDRControl(FDRControl):
             self.metrics,
             has_labels=True,
         )
-        self.preds = dataset[["correct", self.confidence_feature]]
 
         mask = require_labelled_rows(dataset, context="Database-grounded FDR fit")
         labelled = dataset.loc[mask].sort_values(
             by=self.confidence_feature, ascending=False
         )
+        self.preds = labelled[["correct", self.confidence_feature]]
 
         precision = np.cumsum(labelled["correct"]) / np.arange(1, len(labelled) + 1)
         confidence = np.array(labelled[self.confidence_feature])

--- a/winnow/fdr/database_grounded.py
+++ b/winnow/fdr/database_grounded.py
@@ -1,66 +1,59 @@
-from typing import Tuple
-
 import numpy as np
-import pandas as pd
-from instanovo.utils.metrics import Metrics
-from instanovo.utils.residues import ResidueSet
 
-from winnow.datasets.data_loaders.utils import (
-    finalize_peptide_metadata,
-    require_labelled_rows,
-)
+from winnow.datasets.calibration_dataset import CalibrationDataset
+from winnow.datasets.data_loaders.utils import require_labelled_rows
 from winnow.fdr.base import FDRControl
 
 
-class DatabaseGroundedFDRControl(FDRControl):
+class DatabaseGroundedFDRControl(FDRControl[CalibrationDataset]):
     """Performs false discovery rate (FDR) control by grounding predictions against a reference database.
 
     This method estimates FDR thresholds by comparing model-predicted peptides to ground-truth peptides from a database.
+    It expects finalised labelled metadata from a DatasetLoader, including ``correct`` and ``valid_sequence``.
     """
 
     def __init__(
         self,
         confidence_feature: str,
-        residue_masses: dict[str, float],
-        isotope_error_range: Tuple[int, int] = (0, 1),
         drop: int = 10,
     ) -> None:
         super().__init__()
         self.confidence_feature = confidence_feature
-        self.residue_masses = residue_masses
-        self.isotope_error_range = isotope_error_range
         self.drop = drop
 
-        self.metrics = Metrics(
-            residue_set=ResidueSet(residue_masses=residue_masses),
-            isotope_error_range=isotope_error_range,
-        )
+    def fit(self, dataset: CalibrationDataset) -> None:
+        """Computes the precision-recall curve from finalised correctness labels.
 
-    def fit(  # type: ignore
-        self,
-        dataset: pd.DataFrame,
-    ) -> None:
-        """Computes the precision-recall curve by comparing model predictions to database-grounded peptide sequences.
-
-        Per-row correctness is derived from ``sequence`` vs ``prediction``. Rows with
-        ``valid_sequence=False`` receive ``correct=False`` but are excluded from the
-        FDR curve.
+        Rows with ``valid_sequence=False`` are excluded from the FDR curve. Per-row
+        correctness must already be present in ``correct``.
 
         Args:
-            dataset: DataFrame with ``sequence``, ``prediction``, and the confidence
-                column named by ``confidence_feature``.
+            dataset: Finalised calibration dataset with ``correct``, ``valid_sequence``,
+                and the confidence column named by ``confidence_feature``.
+
+        Raises:
+            ValueError: If required finalised label columns are missing.
         """
         assert len(dataset) > 0, "Fit method requires non-empty data"
 
-        finalize_peptide_metadata(
-            dataset,
-            self.metrics,
-            has_labels=True,
-        )
-        self.preds = dataset[["correct", self.confidence_feature]]
+        metadata = dataset.metadata
+        missing = [
+            column
+            for column in ("correct", "valid_sequence", self.confidence_feature)
+            if column not in metadata.columns
+        ]
+        if missing:
+            raise ValueError(
+                "This operation requires finalised labelled metadata with "
+                f"{', '.join(repr(c) for c in missing)}. "
+                "Load labelled data through a DatasetLoader before fitting/running "
+                "diagnostics."
+            )
 
-        mask = require_labelled_rows(dataset, context="Database-grounded FDR fit")
-        labelled = dataset.loc[mask].sort_values(
+        self.preds = metadata[["correct", self.confidence_feature]]
+
+        mask = require_labelled_rows(metadata, context="Database-grounded FDR fit")
+        labelled = metadata.loc[mask].sort_values(
             by=self.confidence_feature, ascending=False
         )
 

--- a/winnow/fdr/database_grounded.py
+++ b/winnow/fdr/database_grounded.py
@@ -55,6 +55,9 @@ class DatabaseGroundedFDRControl(FDRControl[CalibrationDataset]):
         labelled = metadata.loc[mask].sort_values(
             by=self.confidence_feature, ascending=False
         )
+        # If no labelled rows are available, raise an error
+        if len(labelled) == 0:
+            raise ValueError("No labelled rows available for FDR fit")
         self.preds = labelled[["correct", self.confidence_feature]]
 
         precision = np.cumsum(labelled["correct"]) / np.arange(1, len(labelled) + 1)

--- a/winnow/fdr/nonparametric.py
+++ b/winnow/fdr/nonparametric.py
@@ -5,7 +5,7 @@ from numpy.typing import NDArray
 from winnow.fdr.base import FDRControl
 
 
-class NonParametricFDRControl(FDRControl):
+class NonParametricFDRControl(FDRControl[pd.Series]):
     """A non-parametric false discovery rate (FDR) control method that estimates FDR directly from confidence scores.
 
     This implementation uses a non-parametric approach to estimate FDR by computing the cumulative error probabilities across sorted confidence scores.
@@ -19,19 +19,19 @@ class NonParametricFDRControl(FDRControl):
         self._is_correct: NDArray[np.bool_] | None = None
         self._null_scores: NDArray[np.float64] | None = None
 
-    def fit(self, dataset: pd.DataFrame) -> None:
-        """Fit the FDR control method to a dataset of confidence scores.
+    def fit(self, dataset: pd.Series) -> None:
+        """Fit the FDR control method to a series of confidence scores.
 
         Args:
-            dataset (pd.DataFrame):
-                An array of confidence scores from the dataset.
+            dataset: One-dimensional series of confidence scores (for example
+                ``metadata["calibrated_confidence"]``).
         """
         assert len(dataset) > 0, "Fit method requires non-empty data"
-        dataset = dataset.to_numpy()
+        scores = dataset.to_numpy()
 
         # Store sorted confidence scores and their indices
-        self._sorted_indices = np.argsort(-dataset)  # Sort in descending order
-        self._confidence_scores = dataset[self._sorted_indices]
+        self._sorted_indices = np.argsort(-scores)  # Sort in descending order
+        self._confidence_scores = scores[self._sorted_indices]
 
         # Compute error probabilities (1 - confidence)
         error_probabilities = 1 - self._confidence_scores

--- a/winnow/fdr/nonparametric.py
+++ b/winnow/fdr/nonparametric.py
@@ -26,7 +26,9 @@ class NonParametricFDRControl(FDRControl[pd.Series]):
             dataset: One-dimensional series of confidence scores (for example
                 ``metadata["calibrated_confidence"]``).
         """
-        assert len(dataset) > 0, "Fit method requires non-empty data"
+        if len(dataset) == 0:
+            raise ValueError("Fit method requires non-empty data")
+
         scores = dataset.to_numpy()
 
         # Store sorted confidence scores and their indices

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -65,15 +65,16 @@ def filter_dataset(dataset: CalibrationDataset) -> CalibrationDataset:
     Returns:
         CalibrationDataset: The filtered dataset
     """
-    filtered_dataset = (
-        dataset.filter_entries(
-            # Filter out non-list predictions
-            metadata_predicate=lambda row: not isinstance(row["prediction"], list),
-        )
-        # Filter out empty predictions
-        .filter_entries(metadata_predicate=lambda row: not row["prediction"])
+    from winnow.datasets.data_loaders.utils import is_valid_peptide_tokens
+
+    def row_has_valid_prediction(row: pd.Series) -> bool:
+        if "valid_prediction" in row.index:
+            return bool(row["valid_prediction"])
+        return is_valid_peptide_tokens(row["prediction"])
+
+    return dataset.filter_entries(
+        metadata_predicate=lambda row: not row_has_valid_prediction(row),
     )
-    return filtered_dataset
 
 
 def apply_fdr_control(
@@ -499,7 +500,7 @@ def diagnose_calibration_entry_point(
 
     confidence_col = cfg.fdr_control.confidence_column
     diagnostic_data = DiagnosticArrays.from_raw(
-        dataset.metadata[confidence_col],
+        dataset.metadata.loc[labels.index, confidence_col],
         labels,
     )
 

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -524,13 +524,12 @@ def diagnose_calibration_entry_point(
     )
 
     confidence_col = cfg.fdr_control.confidence_column
-    diagnostic_data = DiagnosticArrays.from_raw(
-        dataset.metadata.loc[labels.index, confidence_col],
-        labels,
-    )
+    # Use the same labelled population for FDR cutoff estimation and diagnostics.
+    labelled_scores = dataset.metadata.loc[labels.index, confidence_col]
+    diagnostic_data = DiagnosticArrays.from_raw(labelled_scores, labels)
 
     fdr_control = NonParametricFDRControl()
-    fdr_control.fit(dataset.metadata[confidence_col])
+    fdr_control.fit(labelled_scores)
     conf_cutoff = fdr_control.get_confidence_cutoff(
         threshold=cfg.fdr_control.fdr_threshold
     )

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -90,7 +90,7 @@ def apply_fdr_control(
         fdr_control.fit(dataset=dataset.metadata[confidence_column])
         dataset.metadata = fdr_control.add_psm_pep(dataset.metadata, confidence_column)
     else:
-        fdr_control.fit(dataset=dataset.metadata[confidence_column])
+        fdr_control.fit(dataset=dataset)
 
     dataset.metadata = fdr_control.add_psm_fdr(dataset.metadata, confidence_column)
     dataset.metadata = fdr_control.add_psm_q_value(dataset.metadata, confidence_column)
@@ -423,7 +423,6 @@ def diagnose_calibration_entry_point(
     """Run tail calibration diagnostics on a labelled holdout set."""
     from hydra import initialize_config_dir, compose
     from hydra.utils import instantiate
-    from omegaconf import OmegaConf
 
     from winnow.calibration.calibrator import ProbabilityCalibrator
     from winnow.calibration.diagnostics import (
@@ -469,14 +468,6 @@ def diagnose_calibration_entry_point(
     dataset = filter_dataset(dataset)
     logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
-    residue_masses = OmegaConf.to_container(cfg.residue_masses, resolve=True)
-    residue_remapping_cfg = getattr(cfg.data_loader, "residue_remapping", None)
-    residue_remapping = (
-        {}
-        if residue_remapping_cfg is None
-        else OmegaConf.to_container(residue_remapping_cfg, resolve=True)
-    )
-
     logger.info("Loading trained calibrator.")
     calibrator = ProbabilityCalibrator.load(
         pretrained_model_name_or_path=cfg.calibrator.pretrained_model_name_or_path,
@@ -490,8 +481,6 @@ def diagnose_calibration_entry_point(
         dataset,
         diagnostics.label_source,
         label_column,
-        residue_masses=residue_masses,
-        residue_remapping=residue_remapping,
     )
     logger.info(
         f"Resolved labels via label_source={diagnostics.label_source!r} "

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -57,7 +57,7 @@ def print_config(cfg) -> None:
     formatter.print_config(cfg)
 
 
-def filter_dataset(dataset: CalibrationDataset) -> CalibrationDataset:
+def _filter_dataset(dataset: CalibrationDataset) -> CalibrationDataset:
     """Filter out rows whose predictions are empty or contain unsupported PSMs.
 
     Args:
@@ -78,7 +78,7 @@ def filter_dataset(dataset: CalibrationDataset) -> CalibrationDataset:
     )
 
 
-def apply_fdr_control(
+def _apply_fdr_control(
     fdr_control: Union[NonParametricFDRControl, DatabaseGroundedFDRControl],
     dataset: CalibrationDataset,
     fdr_threshold: float,
@@ -114,7 +114,7 @@ def apply_fdr_control(
     )
 
 
-def separate_metadata_and_predictions(
+def _separate_metadata_and_predictions(
     dataset_metadata: pd.DataFrame,
     confidence_column: str,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
@@ -149,7 +149,7 @@ def separate_metadata_and_predictions(
     return dataset_metadata, dataset_preds_and_fdr_metrics
 
 
-def save_predict_outputs(
+def _save_predict_outputs(
     dataset: CalibrationDataset,
     output_folder: Union[Path, str],
     confidence_column: str,
@@ -165,18 +165,26 @@ def save_predict_outputs(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     formatted_metadata = dataset.format_metadata_for_export()
-    metadata, preds_and_fdr_metrics = separate_metadata_and_predictions(
+    metadata, preds_and_fdr_metrics = _separate_metadata_and_predictions(
         formatted_metadata, confidence_column
     )
     metadata.to_csv(output_dir / "metadata.csv", index=False)
     preds_and_fdr_metrics.to_csv(output_dir / "preds_and_fdr_metrics.csv", index=False)
 
 
-def check_if_labelled(dataset: CalibrationDataset) -> None:
-    """Check if the dataset contains a ground-truth column."""
-    if "sequence" not in dataset.metadata.columns:
+def _check_if_labelled(dataset: CalibrationDataset) -> None:
+    """Check that metadata has finalised labels for database-grounded FDR."""
+    missing = [
+        column
+        for column in ("correct", "valid_sequence")
+        if column not in dataset.metadata.columns
+    ]
+    if missing:
         raise ValueError(
-            "Database-grounded FDR control can only be performed on annotated data."
+            "This operation requires finalised labelled metadata with "
+            f"{', '.join(repr(c) for c in missing)}. "
+            "Load labelled data through a DatasetLoader before fitting/running "
+            "diagnostics."
         )
 
 
@@ -232,7 +240,7 @@ def train_entry_point(
     logger.info(f"Loaded: {len(annotated_dataset.metadata)} spectra")
 
     logger.info("Filtering dataset for empty predictions.")
-    annotated_dataset = filter_dataset(annotated_dataset)
+    annotated_dataset = _filter_dataset(annotated_dataset)
 
     logger.info(f"After filtering: {len(annotated_dataset.metadata)} spectra")
 
@@ -320,7 +328,7 @@ def compute_features_entry_point(
 
     if cfg.filter_empty_predictions:
         logger.info("Filtering dataset for empty predictions.")
-        dataset = filter_dataset(dataset)
+        dataset = _filter_dataset(dataset)
         logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
     logger.info("Instantiating calibrator from config.")
@@ -389,7 +397,7 @@ def predict_entry_point(
     logger.info(f"Loaded: {len(dataset.metadata)} spectra")
 
     logger.info("Filtering dataset for empty predictions.")
-    dataset = filter_dataset(dataset)
+    dataset = _filter_dataset(dataset)
 
     logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
@@ -420,11 +428,11 @@ def predict_entry_point(
 
     # Check if dataset is labelled for database-grounded FDR
     if isinstance(fdr_control, DatabaseGroundedFDRControl):
-        check_if_labelled(dataset)
+        _check_if_labelled(dataset)
 
     # Apply FDR control
     logger.info(f"Applying {fdr_control.__class__.__name__} FDR control.")
-    filtered_dataset = apply_fdr_control(
+    filtered_dataset = _apply_fdr_control(
         fdr_control,
         dataset,
         cfg.fdr_control.fdr_threshold,
@@ -434,7 +442,7 @@ def predict_entry_point(
     # Write output
     logger.info(f"Final dataset: {len(filtered_dataset)} spectra")
     logger.info(f"Writing output to {cfg.output_folder}")
-    save_predict_outputs(
+    _save_predict_outputs(
         filtered_dataset,
         cfg.output_folder,
         cfg.fdr_control.confidence_column,
@@ -493,7 +501,7 @@ def diagnose_calibration_entry_point(
     dataset = data_loader.load(**dataset_params)
     logger.info(f"Loaded: {len(dataset.metadata)} spectra")
 
-    dataset = filter_dataset(dataset)
+    dataset = _filter_dataset(dataset)
     logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
     logger.info("Loading trained calibrator.")

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -7,6 +7,7 @@ needed, significantly reducing --help and config command times.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Union, Tuple, Optional, List, TYPE_CHECKING, Annotated
 import typer
 import logging
@@ -82,22 +83,93 @@ def apply_fdr_control(
     dataset: CalibrationDataset,
     fdr_threshold: float,
     confidence_column: str,
-) -> pd.DataFrame:
-    """Apply FDR control to a dataset."""
+) -> CalibrationDataset:
+    """Apply FDR control and return a filtered dataset without mutating the input.
+
+    Fits the FDR method, annotates a copy of the metadata with FDR columns, then
+    returns a new ``CalibrationDataset`` containing only PSMs at or above the
+    confidence cutoff for ``fdr_threshold``.
+    """
+    from winnow.datasets.calibration_dataset import CalibrationDataset
     from winnow.fdr.nonparametric import NonParametricFDRControl
 
     if isinstance(fdr_control, NonParametricFDRControl):
         fdr_control.fit(dataset=dataset.metadata[confidence_column])
-        dataset.metadata = fdr_control.add_psm_pep(dataset.metadata, confidence_column)
+        metadata = fdr_control.add_psm_pep(dataset.metadata, confidence_column)
     else:
         fdr_control.fit(dataset=dataset)
+        metadata = dataset.metadata
 
-    dataset.metadata = fdr_control.add_psm_fdr(dataset.metadata, confidence_column)
-    dataset.metadata = fdr_control.add_psm_q_value(dataset.metadata, confidence_column)
+    metadata = fdr_control.add_psm_fdr(metadata, confidence_column)
+    metadata = fdr_control.add_psm_q_value(metadata, confidence_column)
     confidence_cutoff = fdr_control.get_confidence_cutoff(threshold=fdr_threshold)
-    output_data = dataset.metadata
-    output_data = output_data[output_data[confidence_column] >= confidence_cutoff]
-    return output_data
+
+    annotated_dataset = CalibrationDataset(
+        metadata=metadata,
+        predictions=dataset.predictions,
+    )
+    # Only retain PSMs with confidence scores equal to or greater than the cutoff
+    return annotated_dataset.filter_entries(
+        metadata_predicate=lambda row: row[confidence_column] < confidence_cutoff
+    )
+
+
+def separate_metadata_and_predictions(
+    dataset_metadata: pd.DataFrame,
+    confidence_column: str,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Separate metadata from prediction and FDR metric columns.
+
+    Args:
+        dataset_metadata: Formatted metadata dataframe to split.
+        confidence_column: Name of the confidence column used for FDR control.
+
+    Returns:
+        Tuple of (metadata without prediction/FDR columns, predictions and FDR metrics).
+    """
+    preds_and_fdr_metrics_cols = [
+        "prediction",
+        confidence_column,
+        "psm_fdr",
+        "psm_q_value",
+    ]
+    if "psm_pep" in dataset_metadata.columns:
+        preds_and_fdr_metrics_cols.append("psm_pep")
+    if "sequence" in dataset_metadata.columns:
+        preds_and_fdr_metrics_cols.append("sequence")
+        if "num_matches" in dataset_metadata.columns:
+            preds_and_fdr_metrics_cols.append("num_matches")
+        if "correct" in dataset_metadata.columns:
+            preds_and_fdr_metrics_cols.append("correct")
+
+    dataset_preds_and_fdr_metrics = dataset_metadata[
+        ["spectrum_id"] + preds_and_fdr_metrics_cols
+    ]
+    dataset_metadata = dataset_metadata.drop(columns=preds_and_fdr_metrics_cols)
+    return dataset_metadata, dataset_preds_and_fdr_metrics
+
+
+def save_predict_outputs(
+    dataset: CalibrationDataset,
+    output_folder: Union[Path, str],
+    confidence_column: str,
+) -> None:
+    """Write predict outputs as separate metadata and prediction/FDR CSV files.
+
+    Args:
+        dataset: Filtered dataset after FDR control.
+        output_folder: Directory for ``metadata.csv`` and ``preds_and_fdr_metrics.csv``.
+        confidence_column: Confidence column to include in the predictions file.
+    """
+    output_dir = Path(output_folder)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    formatted_metadata = dataset.format_metadata_for_export()
+    metadata, preds_and_fdr_metrics = separate_metadata_and_predictions(
+        formatted_metadata, confidence_column
+    )
+    metadata.to_csv(output_dir / "metadata.csv", index=False)
+    preds_and_fdr_metrics.to_csv(output_dir / "preds_and_fdr_metrics.csv", index=False)
 
 
 def check_if_labelled(dataset: CalibrationDataset) -> None:
@@ -106,44 +178,6 @@ def check_if_labelled(dataset: CalibrationDataset) -> None:
         raise ValueError(
             "Database-grounded FDR control can only be performed on annotated data."
         )
-
-
-def separate_metadata_and_predictions(
-    dataset_metadata: pd.DataFrame,
-    fdr_control: Union[NonParametricFDRControl, DatabaseGroundedFDRControl],
-    confidence_column: str,
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """Separate out metadata from prediction and FDR metrics.
-
-    Args:
-        dataset_metadata: The metadata dataframe to separate out prediction and FDR metrics from metadata and computed features.
-        fdr_control: The FDR control object used (to determine which columns were added).
-        confidence_column: The name of the confidence column.
-
-    Returns:
-        Tuple[pd.DataFrame, pd.DataFrame]: A tuple containing the metadata dataframe and the prediction and FDR metrics dataframe.
-    """
-    from winnow.fdr.nonparametric import NonParametricFDRControl
-
-    # Separate out metadata from prediction and FDR metrics
-    preds_and_fdr_metrics_cols = [
-        "prediction",
-        confidence_column,
-        "psm_fdr",
-        "psm_q_value",
-    ]
-    # NonParametricFDRControl adds psm_pep column
-    if isinstance(fdr_control, NonParametricFDRControl):
-        preds_and_fdr_metrics_cols.append("psm_pep")
-    if "sequence" in dataset_metadata.columns:
-        preds_and_fdr_metrics_cols.append("sequence")
-        preds_and_fdr_metrics_cols.append("num_matches")
-        preds_and_fdr_metrics_cols.append("correct")
-    dataset_preds_and_fdr_metrics = dataset_metadata[
-        ["spectrum_id"] + preds_and_fdr_metrics_cols
-    ]
-    dataset_metadata = dataset_metadata.drop(columns=preds_and_fdr_metrics_cols)
-    return dataset_metadata, dataset_preds_and_fdr_metrics
 
 
 def train_entry_point(
@@ -335,7 +369,6 @@ def predict_entry_point(
         return
 
     from winnow.calibration.calibrator import ProbabilityCalibrator
-    from winnow.datasets.calibration_dataset import CalibrationDataset
     from winnow.fdr.database_grounded import DatabaseGroundedFDRControl
 
     logger.info("Starting prediction pipeline.")
@@ -391,7 +424,7 @@ def predict_entry_point(
 
     # Apply FDR control
     logger.info(f"Applying {fdr_control.__class__.__name__} FDR control.")
-    dataset_metadata = apply_fdr_control(
+    filtered_dataset = apply_fdr_control(
         fdr_control,
         dataset,
         cfg.fdr_control.fdr_threshold,
@@ -399,17 +432,12 @@ def predict_entry_point(
     )
 
     # Write output
-    logger.info(f"Final dataset: {len(dataset_metadata)} spectra")
+    logger.info(f"Final dataset: {len(filtered_dataset)} spectra")
     logger.info(f"Writing output to {cfg.output_folder}")
-    dataset_metadata, dataset_preds_and_fdr_metrics = separate_metadata_and_predictions(
-        dataset_metadata, fdr_control, cfg.fdr_control.confidence_column
-    )
-
-    CalibrationDataset(metadata=dataset_metadata).save_metadata(
-        cfg.output_folder + "/" + "metadata.csv"
-    )
-    CalibrationDataset(metadata=dataset_preds_and_fdr_metrics).save_metadata(
-        cfg.output_folder + "/" + "preds_and_fdr_metrics.csv"
+    save_predict_outputs(
+        filtered_dataset,
+        cfg.output_folder,
+        cfg.fdr_control.confidence_column,
     )
 
     logger.info("Prediction pipeline completed successfully.")

--- a/winnow/utils/peptide.py
+++ b/winnow/utils/peptide.py
@@ -20,6 +20,19 @@ def _is_standalone_modification(token: str) -> bool:
     return bool(token) and not token[0].isalpha()
 
 
+def _normalize_token_list(
+    tokens: list[str] | tuple[str, ...] | None,
+) -> list[str] | None:
+    """Coerce token containers from pandas/numpy into a plain Python list."""
+    if tokens is None:
+        return None
+    if hasattr(tokens, "tolist"):
+        return tokens.tolist()
+    if isinstance(tokens, tuple):
+        return list(tokens)
+    return tokens
+
+
 def tokens_to_proforma(tokens: list[str] | None) -> str:
     """Convert a list of tokens to a ProForma compliant string.
 
@@ -46,7 +59,8 @@ def tokens_to_proforma(tokens: list[str] | None) -> str:
         >>> tokens_to_proforma(["M[UNIMOD:35]", "P", "E", "P", "T", "I", "D", "E"])
         'M[UNIMOD:35]PEPTIDE'
     """
-    if not tokens:
+    tokens = _normalize_token_list(tokens)
+    if tokens is None or len(tokens) == 0:
         return ""
 
     # Work with a mutable copy

--- a/winnow/utils/peptide.py
+++ b/winnow/utils/peptide.py
@@ -7,7 +7,7 @@ import pandas as pd
 import polars as pl
 
 
-def _is_missing_cell(value: object) -> bool:
+def is_missing_cell(value: object) -> bool:
     """Return True when a peptide cell is absent (None, NaN, pd.NA)."""
     if value is None:
         return True
@@ -23,7 +23,7 @@ def _is_missing_cell(value: object) -> bool:
 
 def is_usable_peptide_label(value: object) -> bool:
     """Return True when a raw peptide cell contains a label or sequence string."""
-    if _is_missing_cell(value):
+    if is_missing_cell(value):
         return False
     if isinstance(value, str):
         return value.strip() != ""
@@ -46,7 +46,7 @@ def as_token_list(value: object) -> list[str] | None:
     peptide strings; use
     :func:`winnow.datasets.data_loaders.utils.normalize_peptide_cell` for that.
     """
-    if _is_missing_cell(value):
+    if is_missing_cell(value):
         return None
     if isinstance(value, pl.Series):
         tokens = value.to_list()

--- a/winnow/utils/peptide.py
+++ b/winnow/utils/peptide.py
@@ -2,6 +2,68 @@
 
 from __future__ import annotations
 
+import numpy as np
+import pandas as pd
+import polars as pl
+
+
+def _is_missing_cell(value: object) -> bool:
+    """Return True when a peptide cell is absent (None, NaN, pd.NA)."""
+    if value is None:
+        return True
+    if isinstance(value, float) and value != value:
+        return True
+    try:
+        if pd.isna(value):
+            return True
+    except (TypeError, ValueError):
+        pass
+    return False
+
+
+def is_usable_peptide_label(value: object) -> bool:
+    """Return True when a raw peptide cell contains a label or sequence string."""
+    if _is_missing_cell(value):
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (list, tuple)):
+        return len(value) > 0
+    if isinstance(value, pl.Series):
+        return len(value) > 0
+    if isinstance(value, np.ndarray):
+        return value.size > 0
+    if hasattr(value, "tolist"):
+        tokens = value.tolist()
+        return isinstance(tokens, (list, tuple)) and len(tokens) > 0
+    return True
+
+
+def as_token_list(value: object) -> list[str] | None:
+    """Coerce a metadata cell to a non-empty AA token list, or ``None``.
+
+    Accepts container types that already hold token strings. Does not parse raw
+    peptide strings; use
+    :func:`winnow.datasets.data_loaders.utils.normalize_peptide_cell` for that.
+    """
+    if _is_missing_cell(value):
+        return None
+    if isinstance(value, pl.Series):
+        tokens = value.to_list()
+        return list(tokens) if tokens else None
+    if isinstance(value, (list, tuple)):
+        tokens = list(value)
+        return tokens if tokens else None
+    if isinstance(value, np.ndarray):
+        tokens = value.tolist()
+        return tokens if isinstance(tokens, list) and tokens else None
+    return None
+
+
+def is_valid_peptide_tokens(value: object) -> bool:
+    """Return True when a cell holds a non-empty token list (not a raw string)."""
+    return as_token_list(value) is not None
+
 
 def _is_standalone_modification(token: str) -> bool:
     """Check if a token is a standalone modification (not attached to an amino acid).


### PR DESCRIPTION
## Summary

Ports calibration and dataset bug fixes from `revisions`, and merges in the tokenised peptide metadata contract refactor (#227). Peptide tokenisation, validity flags and match columns are now de-duplicated across data loaders, and the finalised-label contract is enforced centrally by `CalibrationDataset` rather than reconstructed by each consumer.

## Changes

### Centralised peptide contract

- **Cell-level helpers moved to `winnow/utils/peptide.py`:** `is_missing_cell`, `is_usable_peptide_label`, `as_token_list`, `is_valid_peptide_tokens`, `tokens_to_proforma`. These are the single source of truth for "what is a valid tokenised peptide".
- **`CalibrationDataset.__post_init__` now enforces the contract:** it requires a tokenised `prediction` column, normalises empty containers to `None`, rejects raw peptide strings, and derives `valid_prediction` (and `valid_sequence` when a `sequence` column is present). It does not parse ProForma or compute `correct` / `num_matches`; those come from the loader.
- **Consumers relying on peptide information require the finalised contract, they no longer impute it.** `ProbabilityCalibrator.fit` and `DatabaseGroundedFDRControl.fit` now take a `CalibrationDataset` and call `require_labelled_rows`, raising if `correct` / `valid_sequence` are missing or no labelled rows remain.

### Shared peptide metadata (`data_loaders/utils.py`)

- `normalize_peptide_cell`, `finalize_peptide_metadata` (pandas + polars for now as polars migration is ongoing), plus `row_num_matches` / `row_is_correct` for per-row match columns.
- Ground-truth detection: a `sequence` column with only empty/null values is treated as unlabelled and dropped at load (`is_usable_peptide_label` gate in the loaders).
- Training mask: `labelled_training_mask` / `require_labelled_rows` select rows with `valid_sequence=True`, and now also require a finalised `correct` column when `sequence` is present.

### Data loaders

- **InstaNovo / MZTab / Winnow:** all route through `finalize_peptide_metadata` instead of per-loader `_evaluate_predictions` / tokenisation paths. The Winnow loader no longer hand-backfills `valid_*`; that is derived centrally by `CalibrationDataset`.
- **InstaNovo L->I remapping** is now applied at the token level only (`_normalize_leucine_tokens`), leaving `prediction_untokenised` as an untouched source column. The previous string-level `.replace("L", "I")` over beam/prediction columns is removed. This is to cover potential cases where modifications contain uppercase "L"s causing remapping to UNIMOD accessions to break.

### Supervised paths exclude invalid ground truth

Rows still get `correct=False` and features, but do not enter fit curves when `valid_sequence=False`:

| Consumer | Behaviour |
|----------|-----------|
| `ProbabilityCalibrator.fit` | Validates labelled columns, computes features, then re-selects the labelled mask (feature computation may drop rows); raises if no labelled rows remain |
| `DatabaseGroundedFDRControl.fit` | Requires finalised `correct` / `valid_sequence`; builds the FDR curve and `self.preds` from labelled rows only; raises on empty labelled set |
| `resolve_diagnostics_labels` | Requires finalised `correct` / `valid_sequence`; restricts sequence-derived labels to valid rows; raises if none |
| `filter_dataset` (`main.py`) | Uses `valid_prediction` when present, else `is_valid_peptide_tokens` |

### Standalone fixes

| Fix | File |
|-----|------|
| `save_metadata` supports `.parquet` | `calibration_dataset.py` |
| Predict / FDR export no longer mutates the input dataset; shared `format_metadata_for_export` used by CSV + parquet; `apply_fdr_control` returns a new `CalibrationDataset` | `calibration_dataset.py`, `scripts/main.py` |
| Calibration diagnostics estimate the FDR cutoff on the same labelled-only population used for the diagnostics arrays | `scripts/main.py` |
| `RetentionTimeFeature` filters out missing / non-token (`None`) predictions before the length and unsupported-residue checks | `retention_time.py` |
| iRT: normalise sequence keys for token containers; unique-peptide / unique-RT checks, empty-metadata early exit, skip Koina when no valid spectra | `retention_time.py` |
| Numpy token arrays handled in `tokens_to_proforma` | `peptide.py` |
| Skip all-empty `sequence` at spectrum load | `utils.load_spectrum_data` |
| Mass error uses shared `is_valid_peptide_tokens` validity check | `mass_error.py` |
| Prefer raising `ValueError` over `AssertionError` in dataset / FDR paths | `calibration_dataset.py`, `fdr/*.py` |

### Docs

- Document the finalised peptide metadata contract and `DatabaseGroundedFDRControl` required columns.
- Add a "fit vs apply" note for database-grounded FDR: `fit` builds the curve from labelled rows only, while applying a cutoff is score-based and label-free, so power users can fit on one labelled dataset and transfer the cutoff to an unlabelled one.

## Reviewer Notes

The contract is now enforced in one place (`CalibrationDataset.__post_init__` plus the shared `winnow/utils/peptide.py` helpers), so consumers assume finalised labels rather than each re-deriving validity. `finalize_peptide_metadata` is still dual-implemented (pandas + polars) because the loaders are mid-migration: MZTab is polars through load/merge; InstaNovo and Winnow are still pandas at the merge boundary; `CalibrationDataset` is pandas end-to-end. The polars/pandas wrappers are thin adapters over the shared cell-level helpers, so behaviour is identical and we avoid a premature full-loader rewrite in this PR.

I would suggest merging #218 and #219 before this PR.
