### PR TITLE
Feat edit distance

### DIFF
--- a/docs/api/features/beam.md
+++ b/docs/api/features/beam.md
@@ -21,6 +21,7 @@ For each spectrum with beam search results `[p₁, p₂, ..., pₙ]` where `p₁
 2. **Median Margin**: `p₁ - median(p₂, ..., pₙ)` (difference from median runner-up)
 3. **Entropy**: Shannon entropy of normalised runner-up distribution
 4. **Z-score**: `(p₁ - mean(all)) / std(all)` (how unusual is the top score)
+5. **Edit distance**: normalised token-level Levenshtein distance between the top-1 and top-2 sequences (I/L treated as identical)
 
 ## Columns
 
@@ -30,6 +31,7 @@ For each spectrum with beam search results `[p₁, p₂, ..., pₙ]` where `p₁
 | `median_margin` | Probability difference (0-1) | Difference between top-1 probability and median probability of runner-ups. |
 | `entropy` | Nats | Shannon entropy of the **normalised** runner-up probability distribution. Higher entropy = more uncertainty among alternatives. |
 | `z-score` | Standard deviations | Z-score of the top-1 probability relative to the full beam distribution (mean and std computed over all beam probabilities). |
+| `edit_distance` | Unitless (0-1) | Normalised Levenshtein distance between top-1 and top-2 token sequences. I and L are treated as the same residue. Larger distance = more dissimilar runner-up. Returns `1.0` when no runner-up exists, when either beam row is missing, or when both sequences are empty. |
 
 ## Usage
 
@@ -51,7 +53,9 @@ The dataset must have beam predictions available (`dataset.predictions` must not
 ## Notes
 
 - A warning is emitted if any beam search results have fewer than two sequences
-- When beam size is 1, margin and entropy default to 0
+- When beam size is 1, margin and entropy default to 0; `edit_distance` defaults to `1.0`
 - Entropy is computed on the **normalised** runner-up probabilities (excluding top-1)
 - Z-score uses the full beam including top-1 for mean/std calculation
+- Edit distance collapses I/L via the same leucine normalisation used elsewhere in the package (`L` → `I`)
+- Both sequences empty is treated as undefined (`1.0`), not as raw Levenshtein zero
 - All probability values are derived from `exp(sequence_log_probability)`

--- a/tests/calibration/features/test_beam.py
+++ b/tests/calibration/features/test_beam.py
@@ -1,12 +1,91 @@
 """Unit tests for winnow calibration feature BeamFeatures."""
 
+from __future__ import annotations
 import pytest
 import pandas as pd
 import numpy as np
 
-from winnow.calibration.features.beam import BeamFeatures
+from winnow.calibration.features.beam import (
+    BeamFeatures,
+    _beam_edit_distance,
+    _normalised_levenshtein,
+    _normalised_levenshtein_ints,
+)
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from tests.calibration.features.conftest import MockScoredSequence
+
+
+class TestNormalisedLevenshtein:
+    """Unit tests for edit distance denominator and non-trivial alignments."""
+
+    def test_both_empty_returns_zero(self):
+        assert _normalised_levenshtein([], []) == pytest.approx(0.0)
+        assert _normalised_levenshtein_ints([], []) == pytest.approx(0.0)
+
+    def test_identical_sequences_zero(self):
+        seq = ["G", "L", "V", "G", "S", "D", "K"]
+        assert _normalised_levenshtein(seq, seq) == pytest.approx(0.0)
+
+    def test_denominator_uses_max_length_short_vs_long(self):
+        # One token vs three: 2 insertions, max(len)=3 -> 2/3
+        assert _normalised_levenshtein(["A"], ["A", "B", "C"]) == pytest.approx(2 / 3)
+        assert _normalised_levenshtein(["A", "B", "C"], ["A"]) == pytest.approx(2 / 3)
+
+    def test_denominator_empty_vs_nonempty(self):
+        # All insertions: distance = len(longer), ratio = 1.0
+        assert _normalised_levenshtein([], ["X", "Y", "Z"]) == pytest.approx(1.0)
+        assert _normalised_levenshtein(["P", "Q"], []) == pytest.approx(1.0)
+
+    def test_denominator_asymmetric_peptide_lengths(self):
+        # KE (2) vs KELEV (5): align K,K and E,E then insert L,E,V -> 3 edits / max(2,5)=5
+        top = ["K", "E"]
+        second = ["K", "E", "L", "E", "V"]
+        assert _normalised_levenshtein(top, second) == pytest.approx(3 / 5)
+
+    def test_multi_edit_alignment(self):
+        """Several subs/ins/dels: exercise full DP (not only single substitution)."""
+        # G L V A vs G L L A: one substitution at position 3 (V vs L)
+        assert _normalised_levenshtein(
+            ["G", "L", "V", "A"], ["G", "L", "L", "A"]
+        ) == pytest.approx(0.25)
+
+        # 7-mer with two substitutions (T↔S, D↔T); raw distance 2 → 2/7
+        a = ["P", "E", "P", "T", "I", "D", "E"]
+        b = ["P", "E", "P", "S", "I", "T", "E"]
+        assert _normalised_levenshtein(a, b) == pytest.approx(2 / 7)
+
+        # Three substitutions on a 7-mer → 3/7 (prefix differs, suffix matches)
+        left = ["A", "A", "A", "D", "E", "F", "G"]
+        right = ["B", "B", "B", "D", "E", "F", "G"]
+        assert _normalised_levenshtein(left, right) == pytest.approx(3 / 7)
+
+
+class TestBeamEditDistance:
+    """Edit distance sentinels for missing or empty beam inputs."""
+
+    def test_both_empty_sequences_use_max_distance(self):
+        beam = [
+            MockScoredSequence([], np.log(0.8)),
+            MockScoredSequence([], np.log(0.6)),
+        ]
+        assert _beam_edit_distance(beam) == pytest.approx(1.0)
+
+    def test_one_empty_sequence_uses_max_distance(self):
+        beam = [
+            MockScoredSequence([], np.log(0.8)),
+            MockScoredSequence(["A"], np.log(0.6)),
+        ]
+        assert _beam_edit_distance(beam) == pytest.approx(1.0)
+
+    def test_none_beam_row_uses_max_distance(self):
+        assert _beam_edit_distance(None) == pytest.approx(1.0)
+
+    def test_empty_beam_list_uses_max_distance(self):
+        assert _beam_edit_distance([]) == pytest.approx(1.0)
+
+    def test_single_beam_uses_max_distance(self):
+        beam = [MockScoredSequence(["A"], np.log(0.8))]
+        assert _beam_edit_distance(beam) == pytest.approx(1.0)
 
 
 class TestBeamFeatures:
@@ -48,6 +127,7 @@ class TestBeamFeatures:
             "median_margin",
             "entropy",
             "z-score",
+            "edit_distance",
         ]
         assert beam_features.dependencies == []
 
@@ -70,15 +150,24 @@ class TestBeamFeatures:
             beam_features.compute(sample_dataset_with_predictions)
 
         # Check that all expected columns were added
-        expected_columns = ["margin", "median_margin", "entropy", "z-score"]
+        expected_columns = [
+            "margin",
+            "median_margin",
+            "entropy",
+            "z-score",
+            "edit_distance",
+        ]
         for col in expected_columns:
             assert col in sample_dataset_with_predictions.metadata.columns
 
         # Check that we have the right number of rows
         assert len(sample_dataset_with_predictions.metadata) == 3
 
-    def test_compute_with_none_predictions(self, beam_features):
-        """Test that compute raises error when predictions is None."""
+        # Third spectrum has only one beam sequence: edit distance is 1.0
+        assert sample_dataset_with_predictions.metadata.iloc[2]["edit_distance"] == 1.0
+
+    def test_compute_raises_when_beam_predictions_not_loaded(self, beam_features):
+        """BeamFeatures requires a predictions list; None means beams were not loaded."""
         metadata = pd.DataFrame({"confidence": [0.9]})
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
@@ -87,6 +176,69 @@ class TestBeamFeatures:
             match="requires beam predictions, but dataset.predictions is None",
         ):
             beam_features.compute(dataset)
+
+    def test_compute_with_none_beam_row(self, beam_features):
+        """Database-search rows without beam candidates use max edit distance."""
+        metadata = pd.DataFrame({"confidence": [0.9, 0.8]})
+        predictions = [
+            None,
+            [
+                MockScoredSequence(["A"], np.log(0.8)),
+                MockScoredSequence(["G"], np.log(0.6)),
+            ],
+        ]
+        dataset = CalibrationDataset(metadata=metadata, predictions=predictions)
+
+        with pytest.warns(
+            UserWarning,
+            match="1 beam search results have fewer than two sequences",
+        ):
+            beam_features.compute(dataset)
+
+        assert dataset.metadata.iloc[0]["edit_distance"] == pytest.approx(1.0)
+        assert dataset.metadata.iloc[0]["margin"] == pytest.approx(0.0)
+        assert dataset.metadata.iloc[1]["edit_distance"] == pytest.approx(1.0)
+
+    def test_compute_with_empty_beam_list(self, beam_features):
+        """An empty beam list is treated like a missing runner-up."""
+        metadata = pd.DataFrame({"confidence": [0.9]})
+        dataset = CalibrationDataset(metadata=metadata, predictions=[[]])
+
+        with pytest.warns(
+            UserWarning,
+            match="1 beam search results have fewer than two sequences",
+        ):
+            beam_features.compute(dataset)
+
+        assert dataset.metadata.iloc[0]["edit_distance"] == pytest.approx(1.0)
+
+    def test_compute_edit_distance_both_empty_sequences(self, beam_features):
+        """Two present beam slots with empty token lists use max edit distance."""
+        metadata = pd.DataFrame({"confidence": [0.9]})
+        predictions = [
+            [
+                MockScoredSequence([], np.log(0.8)),
+                MockScoredSequence([], np.log(0.6)),
+            ]
+        ]
+        dataset = CalibrationDataset(metadata=metadata, predictions=predictions)
+        beam_features.compute(dataset)
+
+        assert dataset.metadata.iloc[0]["edit_distance"] == pytest.approx(1.0)
+
+    def test_compute_edit_distance_one_empty_sequence(self, beam_features):
+        """One empty and one non-empty sequence uses max edit distance."""
+        metadata = pd.DataFrame({"confidence": [0.9]})
+        predictions = [
+            [
+                MockScoredSequence([], np.log(0.8)),
+                MockScoredSequence(["A", "G"], np.log(0.6)),
+            ]
+        ]
+        dataset = CalibrationDataset(metadata=metadata, predictions=predictions)
+        beam_features.compute(dataset)
+
+        assert dataset.metadata.iloc[0]["edit_distance"] == pytest.approx(1.0)
 
     def test_compute_with_insufficient_sequences_warning(self, beam_features):
         """Test that warning is issued for beam results with < 2 sequences."""
@@ -105,6 +257,8 @@ class TestBeamFeatures:
             match="1 beam search results have fewer than two sequences. This may affect the efficacy of computed beam features.",
         ):
             beam_features.compute(dataset)
+
+        assert dataset.metadata.iloc[0]["edit_distance"] == 1.0
 
     def test_margin_calculation(self, beam_features):
         """Test specific margin calculation."""
@@ -162,6 +316,9 @@ class TestBeamFeatures:
             0.0, rel=1e-10, abs=1e-10
         )  # std_prob = 0, so z-score = 0
 
+        # No second sequence: edit distance is undefined
+        assert dataset.metadata.iloc[0]["edit_distance"] == 1.0
+
     def test_beam_features_with_two_sequences(self, beam_features):
         """Test beam feature calculations with two sequences."""
         metadata = pd.DataFrame({"confidence": [0.9]})
@@ -203,6 +360,9 @@ class TestBeamFeatures:
             expected_z_score, rel=1e-10, abs=1e-10
         )
 
+        # edit_distance: ["A"] vs ["G"] = 1 substitution / max(1,1) = 1.0
+        assert dataset.metadata.iloc[0]["edit_distance"] == pytest.approx(1.0)
+
     def test_beam_features_with_three_sequences(self, beam_features):
         """Test beam feature calculations with three sequences."""
         metadata = pd.DataFrame({"confidence": [0.9]})
@@ -243,6 +403,38 @@ class TestBeamFeatures:
         z_score = dataset.metadata.iloc[0]["z-score"]
         assert z_score == pytest.approx(1.3970013970020956, rel=1e-10, abs=1e-10)
 
+        # edit_distance: ["A"] vs ["G"] = 1 substitution / max(1,1) = 1.0
+        assert dataset.metadata.iloc[0]["edit_distance"] == pytest.approx(1.0)
+
+    def test_beam_features_edit_distance_ignores_li(self, beam_features):
+        """Test that edit distance treats L and I as identical."""
+        metadata = pd.DataFrame({"confidence": [0.9]})
+        predictions = [
+            [
+                MockScoredSequence(["L", "A", "G"], np.log(0.8)),
+                MockScoredSequence(["I", "A", "G"], np.log(0.6)),
+            ]
+        ]
+        dataset = CalibrationDataset(metadata=metadata, predictions=predictions)
+        beam_features.compute(dataset)
+
+        assert dataset.metadata.iloc[0]["edit_distance"] == pytest.approx(0.0)
+
+    def test_beam_features_edit_distance_mixed(self, beam_features):
+        """Test edit distance with L/I equivalence and real differences."""
+        metadata = pd.DataFrame({"confidence": [0.9]})
+        predictions = [
+            [
+                MockScoredSequence(["L", "A", "K"], np.log(0.8)),
+                MockScoredSequence(["I", "G", "K"], np.log(0.6)),
+            ]
+        ]
+        dataset = CalibrationDataset(metadata=metadata, predictions=predictions)
+        beam_features.compute(dataset)
+
+        # L->I is free (both normalised to L), A->G is 1 substitution / max(3,3) = 1/3
+        assert dataset.metadata.iloc[0]["edit_distance"] == pytest.approx(1 / 3)
+
     def test_beam_features_edge_case_equal_probabilities(self, beam_features):
         """Test beam features when all sequences have equal probabilities."""
         metadata = pd.DataFrame({"confidence": [0.9]})
@@ -273,11 +465,3 @@ class TestBeamFeatures:
         assert dataset.metadata.iloc[0]["z-score"] == pytest.approx(
             0.0, rel=1e-10, abs=1e-10
         )
-
-    def test_beam_features_raises_for_none_predictions(self, beam_features):
-        """BeamFeatures.compute should raise ValueError when predictions is None."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
-        dataset = CalibrationDataset(metadata=metadata, predictions=None)
-
-        with pytest.raises(ValueError, match="BeamFeatures requires beam predictions"):
-            beam_features.compute(dataset)

--- a/winnow/calibration/features/beam.py
+++ b/winnow/calibration/features/beam.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List, Optional
 import warnings
 import numpy as np
 from math import exp
@@ -8,6 +8,78 @@ from numpy import median
 from winnow.calibration.features.base import CalibrationFeatures, FeatureDependency
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.calibration.features.utils import require_beam_predictions
+
+
+def _beam_len(beam: Optional[List]) -> int:
+    """Return the number of scored sequences in a beam row (0 for ``None``)."""
+    return 0 if beam is None else len(beam)
+
+
+def _normalise_li(tokens: List[str]) -> List[str]:
+    """Replace every 'I' token with 'L' so leucine/isoleucine are treated identically."""
+    return ["L" if t == "I" else t for t in tokens]
+
+
+def _normalised_levenshtein(sequence_a: List[str], sequence_b: List[str]) -> float:
+    """Normalised token-level Levenshtein distance between two sequences.
+
+    Tokens are mapped to consecutive integers per pair comparison so the dynamic
+    program compares small ints instead of strings.
+
+    Returns the edit distance divided by the length of the longer sequence,
+    giving a value in [0, 1]. Returns 0.0 when both sequences are empty.
+    """
+    residue_to_id: Dict[str, int] = {}
+
+    def _to_ints(sequence: List[str]) -> List[int]:
+        return [
+            residue_to_id.setdefault(residue, len(residue_to_id))
+            for residue in sequence
+        ]
+
+    a_ints = _to_ints(sequence_a)
+    b_ints = _to_ints(sequence_b)
+    return _normalised_levenshtein_ints(a_ints, b_ints)
+
+
+def _normalised_levenshtein_ints(a: List[int], b: List[int]) -> float:
+    """Levenshtein on integer token ids; result normalised by max(len(a), len(b))."""
+    n, m = len(a), len(b)
+    max_len = max(n, m)
+    if max_len == 0:
+        return 0.0
+
+    prev = list(range(m + 1))
+    curr = [0] * (m + 1)
+    for i in range(1, n + 1):
+        curr[0] = i
+        ai = a[i - 1]
+        for j in range(1, m + 1):
+            cost = 0 if ai == b[j - 1] else 1
+            res = prev[j] + 1
+            if curr[j - 1] + 1 < res:
+                res = curr[j - 1] + 1
+            if prev[j - 1] + cost < res:
+                res = prev[j - 1] + cost
+            curr[j] = res
+        prev, curr = curr, prev
+    return prev[m] / max_len
+
+
+def _beam_edit_distance(beam: Optional[List]) -> float:
+    """Normalised top-1 vs top-2 edit distance, or 1.0 when undefined."""
+    if _beam_len(beam) < 2:
+        return 1.0
+
+    assert beam is not None
+    top_seq = beam[0].sequence or []
+    second_seq = beam[1].sequence or []
+    if not top_seq and not second_seq:
+        return 1.0
+    return _normalised_levenshtein(
+        _normalise_li(top_seq),
+        _normalise_li(second_seq),
+    )
 
 
 class BeamFeatures(CalibrationFeatures):
@@ -40,9 +112,15 @@ class BeamFeatures(CalibrationFeatures):
         """Defines the column names for the computed features.
 
         Returns:
-            List[str]: A list of column names: ["margin", "median_margin", "entropy", "z-score"].
+            List[str]: A list of column names: ["margin", "median_margin", "entropy", "z-score", "edit_distance"].
         """
-        return ["margin", "median_margin", "entropy", "z-score"]
+        return [
+            "margin",
+            "median_margin",
+            "entropy",
+            "z-score",
+            "edit_distance",
+        ]
 
     def prepare(self, dataset: CalibrationDataset) -> None:
         """Prepares the dataset before feature computation.
@@ -61,6 +139,7 @@ class BeamFeatures(CalibrationFeatures):
         - Median Margin: Difference between the highest probability sequence and the median probability of the runner-ups.
         - Entropy: Shannon entropy of the normalised probabilities of the runner-up sequences.
         - Z-score: Distance between the top beam score and the population mean over all beam results for that spectra in units of the standard deviation.
+        - Edit distance: Normalised Levenshtein distance between the top-1 and top-2 sequences, treating I/L as the same residue. Returns 1.0 when no runner-up exists, when either beam row is missing, or when both sequences are empty.
 
         These metrics help assess the confidence of the top prediction relative to lower-ranked candidates.
 
@@ -71,7 +150,7 @@ class BeamFeatures(CalibrationFeatures):
         require_beam_predictions(dataset, "BeamFeatures")
         assert dataset.predictions is not None
 
-        count = sum(len(prediction) < 2 for prediction in dataset.predictions)  # type: ignore
+        count = sum(_beam_len(prediction) < 2 for prediction in dataset.predictions)
         if count > 0:
             warnings.warn(
                 f"{count} beam search results have fewer than two sequences. "
@@ -79,11 +158,15 @@ class BeamFeatures(CalibrationFeatures):
             )
 
         top_probs = [
-            exp(prediction[0].sequence_log_probability) if len(prediction) >= 1 else 0.0  # type: ignore
+            exp(prediction[0].sequence_log_probability)  # type: ignore
+            if _beam_len(prediction) >= 1
+            else 0.0
             for prediction in dataset.predictions
         ]
         second_probs = [
-            exp(prediction[1].sequence_log_probability) if len(prediction) >= 2 else 0.0  # type: ignore
+            exp(prediction[1].sequence_log_probability)  # type: ignore
+            if _beam_len(prediction) >= 2
+            else 0.0
             for prediction in dataset.predictions
         ]
         second_margin = [
@@ -92,7 +175,7 @@ class BeamFeatures(CalibrationFeatures):
         ]
         runner_up_probs = [
             [exp(item.sequence_log_probability) for item in prediction[1:]]  # type: ignore
-            if len(prediction) >= 2  # type: ignore
+            if _beam_len(prediction) >= 2
             else [0.0]
             for prediction in dataset.predictions
         ]
@@ -114,6 +197,8 @@ class BeamFeatures(CalibrationFeatures):
 
         # Function to compute mean, std, and z-score over a row's beam results
         def row_beam_z_score(row):
+            if row is None or len(row) == 0:
+                return 0.0
             probabilities = [exp(beam.sequence_log_probability) for beam in row]
             mean_prob = np.mean(probabilities)
             std_prob = np.std(probabilities)
@@ -123,8 +208,12 @@ class BeamFeatures(CalibrationFeatures):
 
         z_score = [row_beam_z_score(prediction) for prediction in dataset.predictions]
 
-        # dataset.metadata['confidence'] = top_probs
+        edit_distances = [
+            _beam_edit_distance(prediction) for prediction in dataset.predictions
+        ]
+
         dataset.metadata["margin"] = second_margin
         dataset.metadata["median_margin"] = median_margin
         dataset.metadata["entropy"] = runner_up_entropy
         dataset.metadata["z-score"] = z_score
+        dataset.metadata["edit_distance"] = edit_distances

--- a/winnow/calibration/features/beam.py
+++ b/winnow/calibration/features/beam.py
@@ -8,16 +8,12 @@ from numpy import median
 from winnow.calibration.features.base import CalibrationFeatures, FeatureDependency
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.calibration.features.utils import require_beam_predictions
+from winnow.datasets.data_loaders.utils import _normalize_leucine_tokens
 
 
 def _beam_len(beam: Optional[List]) -> int:
     """Return the number of scored sequences in a beam row (0 for ``None``)."""
     return 0 if beam is None else len(beam)
-
-
-def _normalise_li(tokens: List[str]) -> List[str]:
-    """Replace every 'I' token with 'L' so leucine/isoleucine are treated identically."""
-    return ["L" if t == "I" else t for t in tokens]
 
 
 def _normalised_levenshtein(sequence_a: List[str], sequence_b: List[str]) -> float:
@@ -74,16 +70,18 @@ def _beam_edit_distance(beam: Optional[List]) -> float:
     assert beam is not None
     top_seq = beam[0].sequence or []
     second_seq = beam[1].sequence or []
+    # Treat both-empty as undefined (same as missing runner-up), not raw
+    # Levenshtein 0.0 which would look spuriously confident.
     if not top_seq and not second_seq:
         return 1.0
     return _normalised_levenshtein(
-        _normalise_li(top_seq),
-        _normalise_li(second_seq),
+        _normalize_leucine_tokens(top_seq),
+        _normalize_leucine_tokens(second_seq),
     )
 
 
 class BeamFeatures(CalibrationFeatures):
-    """Calculates the margin, median margin and entropy of beam runners-up."""
+    """Calculates margin, median margin, entropy, z-score and edit distance of beam runners-up."""
 
     @property
     def dependencies(self) -> List[FeatureDependency]:
@@ -133,7 +131,7 @@ class BeamFeatures(CalibrationFeatures):
         return
 
     def compute(self, dataset: CalibrationDataset) -> None:
-        """Computes margin, median margin and entropy for beam search runners-up.
+        """Computes margin, median margin, entropy, z-score and edit distance for beam search runners-up.
 
         - Margin: Difference between the highest probability sequence and the second-best sequence.
         - Median Margin: Difference between the highest probability sequence and the median probability of the runner-ups.


### PR DESCRIPTION
## Summary

Add **`edit_distance`** to `BeamFeatures`: normalised token-level Levenshtein between top-1 and top-2 beam sequences, with I/L equivalence. Undefined cases (fewer than two candidates, null/empty beam rows, missing sequences) return `1.0`.