### PR TITLE
Fix tokenised dataset contract

### DIFF
--- a/docs/api/calibration.md
+++ b/docs/api/calibration.md
@@ -94,7 +94,7 @@ The calibrator uses a feature-based approach where multiple feature extractors c
 
 1. **Create Calibrator**: Initialise `ProbabilityCalibrator`
 2. **Add Features**: Use `add_feature()` to include desired calibration features
-3. **Fit Model**: Call `fit()` with labelled `CalibrationDataset`
+3. **Fit Model**: Call `fit()` with a labelled `CalibrationDataset`
 4. **Save Model**: Use `save()` to persist trained calibrator
 
 ### Prediction workflow
@@ -110,7 +110,7 @@ The calibrator uses a feature-based approach where multiple feature extractors c
    # Option 3: Use local model
    calibrator = ProbabilityCalibrator.load("./my_calibrator")
    ```
-2. **Predict**: Call `predict()` with unlabelled `CalibrationDataset`
+2. **Predict**: Call `predict()` with an unlabelled `CalibrationDataset`
 3. **Access Results**: Calibrated scores stored in dataset's "calibrated_confidence" column
 
 For detailed examples and usage patterns, refer to the [examples notebook](https://github.com/instadeepai/winnow/blob/main/examples/getting_started_with_winnow.ipynb).

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -39,6 +39,8 @@ dataset.save(Path("output_directory"))
 
 - **Multiple Format Support**: Load data using specialised loaders for different file formats
 - **Data Integration**: Combines spectral data with prediction metadata
+- **Tokenised Peptides**: Loaders normalise `prediction` (and labelled `sequence`) to token lists and write `valid_prediction` / `valid_sequence` (plus `correct` / `num_matches` when labelled)
+- **Structural Gate**: Direct `CalibrationDataset` construction requires already-tokenised peptide columns.
 - **Filtering**: Removes invalid tokens and unsupported modifications
 - **Evaluation**: Computes correctness labels when ground truth available
 

--- a/docs/api/fdr.md
+++ b/docs/api/fdr.md
@@ -94,7 +94,7 @@ from winnow.fdr import NonParametricFDRControl
 # Create non-parametric FDR controller
 fdr_control = NonParametricFDRControl()
 
-# Fit estimation method to confidence scores
+# Fit estimation method to a Series of confidence scores
 fdr_control.fit(dataset=dataset["confidence"])
 
 # Get confidence cutoff for 5% FDR

--- a/docs/api/fdr.md
+++ b/docs/api/fdr.md
@@ -65,9 +65,9 @@ dataset_with_q_values = fdr_control.add_psm_q_value(dataset, "confidence")
 
 **Required Data:**
 
-- Ground truth peptide sequences (`sequence` column)
-- Predicted peptide sequences (`prediction` column)
 - Confidence scores (configurable column name)
+- Boolean PSM correctness column (`correct`)
+- Boolean ground-truth sequence validity column (`valid_sequence`) used for filtering
 
 ### NonParametricFDRControl
 

--- a/docs/api/fdr.md
+++ b/docs/api/fdr.md
@@ -30,33 +30,18 @@ from winnow.fdr.base import FDRControl
 Implements database-grounded FDR control using database search results as ground truth for FDR estimation.
 
 ```python
+from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.fdr import DatabaseGroundedFDRControl
-residue_masses = {
-            "G": 57.021464,
-            "A": 71.037114,
-            "P": 97.052764,
-            "E": 129.042593,
-            "T": 101.047670,
-            "I": 113.084064,
-            "D": 115.026943,
-            "R": 156.101111,
-            "O": 237.147727,
-            "N": 114.042927,
-            "S": 87.032028,
-            "M": 131.040485,
-            "L": 113.084064,
-        }
 
 # Create FDR controller
-fdr_control = DatabaseGroundedFDRControl(confidence_feature="confidence")
-
-# Fit using labelled dataset
-fdr_control.fit(
-    dataset=labelled_dataframe,
-    residue_masses=residue_masses,
-    isotope_error_range=(0, 1),
-    drop=10  # Drop top N predictions for stability
+fdr_control = DatabaseGroundedFDRControl(
+    confidence_feature="confidence",
+    drop=10,  # Drop top N predictions for stability
 )
+
+# Fit using a CalibrationDataset with loader-finalised metadata
+# (requires correct, valid_sequence and confidence columns)
+fdr_control.fit(dataset=calibration_dataset)
 
 # Get confidence cutoff for 1% FDR
 confidence_cutoff = fdr_control.get_confidence_cutoff(threshold=0.01)
@@ -73,10 +58,10 @@ dataset_with_q_values = fdr_control.add_psm_q_value(dataset, "confidence")
 
 **Key Features:**
 
-- **Ground Truth Validation**: Uses database search results for validation
-- **Precision-Recall Analysis**: Computes precision-recall curves from predictions
-- **Isotope Error Handling**: Supports configurable isotope error ranges
+- **Ground Truth Validation**: Uses loader-derived `correct` labels from database-grounded sequences
+- **Precision-Recall Analysis**: Computes precision-recall curves from finalised predictions
 - **Stability Control**: Drop parameter for robust threshold estimation
+- **Finalised Metadata Only**: Does not tokenise peptides or compute match labels; prefer loading labelled data through a DatasetLoader first
 
 **Required Data:**
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -154,7 +154,7 @@ By default, `winnow predict` uses the pretrained model `InstaDeepAI/winnow-gener
 
 ### `winnow diagnose-calibration`
 
-Assess tail calibration on a labelled holdout set before trusting non-parametric FDR at your operating threshold. The command applies a trained calibrator, derives the confidence cutoff $\tau$ at `fdr_control.fdr_threshold`, estimates signed tail expected calibration error (sTECE) and TECE on $\{S \ge \tau\}$ using isotonic regression, writes a reliability diagram, and warns when $|\widehat{\mathrm{sTECE}}(\tau)|$ exceeds `diagnostics.tolerance` (default `0.005`, i.e. 0.5 percentage points on the FDR scale, which is about 10% of a 5% FDR target).
+Assess tail calibration on a labelled holdout set before trusting non-parametric FDR at your operating threshold. The command applies a trained calibrator, derives the confidence cutoff $\tau$ at `fdr_control.fdr_threshold` from the same labelled population used for diagnostics (for `label_source=sequence`, rows with `valid_sequence=True`), estimates signed tail expected calibration error (sTECE) and TECE on $\{S \ge \tau\}$ using isotonic regression, writes a reliability diagram, and warns when $|\widehat{\mathrm{sTECE}}(\tau)|$ exceeds `diagnostics.tolerance` (default `0.005`, i.e. 0.5 percentage points on the FDR scale, which is about 10% of a 5% FDR target).
 
 **Configuration:** see [Calibration diagnostic configuration](configuration.md#calibration-diagnostic-configuration) for the full parameter reference.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -413,18 +413,14 @@ No additional parameters required.
 ```yaml
 _target_: winnow.fdr.database_grounded.DatabaseGroundedFDRControl
 confidence_feature: ${fdr_control.confidence_column}
-residue_masses: ${residue_masses}
-isotope_error_range: [0, 1]
 drop: 10
 ```
 
-Requires ground truth sequences in the dataset.
+Requires finalised labelled metadata from a DatasetLoader (`correct` and `valid_sequence`).
 
 **Key parameters:**
 
 - `confidence_feature`: Name of the column with confidence scores (interpolated from fdr_control)
-- `residue_masses`: Amino acid and modification masses (interpolated from residues config)
-- `isotope_error_range`: Range of isotope errors to consider when matching peptides
 - `drop`: Number of top predictions to drop for stability
 
 ## Calibration diagnostic configuration
@@ -483,7 +479,7 @@ You must choose exactly one labelling mode. The command validates config before 
 
 | `label_source` | `label_column` | Behaviour |
 | --- | --- | --- |
-| `sequence` | must be `null` | Derive `correct` from full-sequence match of `sequence` vs `prediction` (uses `residue_masses` from `residues.yaml`). |
+| `sequence` | must be `null` | Use loader-finalised `correct` labels (and exclude rows with `valid_sequence=False`). |
 | `precomputed` | required (e.g. `proteome_hit`) | Read boolean labels from the named column in merged metadata (e.g. offline proteome mapping). |
 
 Extra label columns in the input file (e.g. `proteome_hit` when using `sequence`) are ignored. If both `sequence` and a precomputed column exist, only the path chosen by `label_source` is used.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -427,7 +427,7 @@ Requires finalised labelled metadata from a DatasetLoader (`correct` and `valid_
 
 ### Main config (`configs/diagnose_calibration.yaml`)
 
-Runs tail calibration diagnostics on a labelled holdout set: loads data like `winnow predict`, applies a pretrained calibrator, derives the operating cutoff $\tau$ at `fdr_control.fdr_threshold`, and reports sTECE and TECE on $\{S \ge \tau\}$. See the [CLI reference](cli.md#winnow-diagnose-calibration) for usage examples and interpretation.
+Runs tail calibration diagnostics on a labelled holdout set: loads data like `winnow predict`, applies a pretrained calibrator, derives the operating cutoff $\tau$ at `fdr_control.fdr_threshold` on the labelled diagnostic population, and reports sTECE and TECE on $\{S \ge \tau\}$. See the [CLI reference](cli.md#winnow-diagnose-calibration) for usage examples and interpretation.
 
 ```yaml
 defaults:

--- a/tests/calibration/features/test_base.py
+++ b/tests/calibration/features/test_base.py
@@ -56,7 +56,9 @@ class TestConcreteFeatureImplementation:
     def test_concrete_feature_compute(self):
         """Test that concrete feature can compute values."""
         feature = ConcreteFeature()
-        metadata = pd.DataFrame({"existing_col": [1, 2, 3]})
+        metadata = pd.DataFrame(
+            {"existing_col": [1, 2, 3], "prediction": [["A"], ["G"], ["K"]]}
+        )
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         feature.compute(dataset)

--- a/tests/calibration/features/test_beam.py
+++ b/tests/calibration/features/test_beam.py
@@ -20,7 +20,9 @@ class TestBeamFeatures:
     @pytest.fixture()
     def sample_dataset_with_predictions(self):
         """Create a sample dataset with beam search predictions."""
-        metadata = pd.DataFrame({"confidence": [0.9, 0.8, 0.7]})
+        metadata = pd.DataFrame(
+            {"confidence": [0.9, 0.8, 0.7], "prediction": [["A"], ["G"], ["K"]]}
+        )
 
         # Mock beam search results with different numbers of sequences
         predictions = [
@@ -79,7 +81,7 @@ class TestBeamFeatures:
 
     def test_compute_with_none_predictions(self, beam_features):
         """Test that compute raises error when predictions is None."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         with pytest.raises(
@@ -90,7 +92,9 @@ class TestBeamFeatures:
 
     def test_compute_with_insufficient_sequences_warning(self, beam_features):
         """Test that warning is issued for beam results with < 2 sequences."""
-        metadata = pd.DataFrame({"confidence": [0.9, 0.8]})
+        metadata = pd.DataFrame(
+            {"confidence": [0.9, 0.8], "prediction": [["A"], ["G"]]}
+        )
         predictions = [
             [MockScoredSequence(["A"], np.log(0.8))],  # Only 1 sequence
             [
@@ -108,7 +112,7 @@ class TestBeamFeatures:
 
     def test_margin_calculation(self, beam_features):
         """Test specific margin calculation."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [
                 MockScoredSequence(["A"], np.log(0.8)),  # top = 0.8
@@ -126,7 +130,7 @@ class TestBeamFeatures:
 
     def test_beam_features_with_one_sequence(self, beam_features):
         """Test beam feature calculations with single sequence."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [MockScoredSequence(["A"], np.log(0.8))]  # Single sequence
         ]
@@ -164,7 +168,7 @@ class TestBeamFeatures:
 
     def test_beam_features_with_two_sequences(self, beam_features):
         """Test beam feature calculations with two sequences."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [
                 MockScoredSequence(["A"], np.log(0.8)),  # top
@@ -205,7 +209,7 @@ class TestBeamFeatures:
 
     def test_beam_features_with_three_sequences(self, beam_features):
         """Test beam feature calculations with three sequences."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [
                 MockScoredSequence(["A"], np.log(0.7)),  # top
@@ -245,7 +249,7 @@ class TestBeamFeatures:
 
     def test_beam_features_edge_case_equal_probabilities(self, beam_features):
         """Test beam features when all sequences have equal probabilities."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         predictions = [
             [
                 MockScoredSequence(["A"], np.log(1 / 3)),
@@ -276,7 +280,7 @@ class TestBeamFeatures:
 
     def test_beam_features_raises_for_none_predictions(self, beam_features):
         """BeamFeatures.compute should raise ValueError when predictions is None."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         with pytest.raises(ValueError, match="BeamFeatures requires beam predictions"):

--- a/tests/calibration/features/test_chimeric.py
+++ b/tests/calibration/features/test_chimeric.py
@@ -30,6 +30,7 @@ class TestChimericFeatures:
         metadata = pd.DataFrame(
             {
                 "confidence": [0.9, 0.8, 0.7],
+                "prediction": [["A", "G"], ["V", "T"], ["K"]],
                 "precursor_charge": [2, 2, 3],
                 "spectrum_id": [0, 1, 2],
                 "mz_array": [
@@ -168,7 +169,9 @@ class TestChimericFeatures:
 
     def test_compute_with_none_predictions(self, chimeric_features):
         """Test that compute raises error when predictions is None."""
-        metadata = pd.DataFrame({"confidence": [0.9], "precursor_charge": [2]})
+        metadata = pd.DataFrame(
+            {"confidence": [0.9], "prediction": [["A"]], "precursor_charge": [2]}
+        )
         dataset = CalibrationDataset(metadata=metadata, predictions=None)
 
         with pytest.raises(
@@ -182,6 +185,7 @@ class TestChimericFeatures:
         metadata = pd.DataFrame(
             {
                 "confidence": [0.9],
+                "prediction": [["A"]],
                 "precursor_charge": [2],
             }
         )
@@ -302,6 +306,7 @@ class TestChimericFeatures:
         metadata = pd.DataFrame(
             {
                 "confidence": [0.9, 0.7, 0.6],
+                "prediction": [["A", "G"], ["K"], ["S", "P"]],
                 "precursor_charge": [2, 2, 7],  # Last one has charge > 6
                 "spectrum_id": [10, 30, 40],
                 "mz_array": [
@@ -372,6 +377,7 @@ class TestChimericFeatures:
         )
         metadata = pd.DataFrame(
             {
+                "prediction": [["A", "G"], ["V", "T"], ["S", "P"]],
                 "precursor_charge": [2, 2, 2],
                 "spectrum_id": [10, 20, 30],
                 "mz_array": [[100.0, 200.0], [120.0], [110.0, 210.0]],

--- a/tests/calibration/features/test_mass_error.py
+++ b/tests/calibration/features/test_mass_error.py
@@ -167,21 +167,6 @@ class TestMassErrorPPMFeature:
         result = dataset.metadata.iloc[0]["mass_error_ppm"]
         assert result < 0
 
-    def test_compute_with_invalid_peptide(self, residue_masses):
-        """When prediction is not a list, compute should raise."""
-        feature = MassErrorPPMFeature(residue_masses=residue_masses)
-        metadata = pd.DataFrame(
-            {
-                "precursor_mz": [500.503638],
-                "precursor_charge": [2],
-                "prediction": ["invalid_string"],
-            }
-        )
-        dataset = CalibrationDataset(metadata=metadata, predictions=None)
-
-        with pytest.raises(ValueError, match="not valid peptide sequences"):
-            feature.compute(dataset)
-
     def test_custom_residue_masses(self):
         """Test that custom residue masses are used correctly."""
         custom_masses = {"A": 100.0, "G": 200.0}
@@ -333,21 +318,6 @@ class TestMassErrorDaFeature:
 
         result = dataset.metadata.iloc[0]["mass_error_da"]
         assert result < 0
-
-    def test_compute_with_invalid_peptide(self, residue_masses):
-        """When prediction is not a list, compute should raise."""
-        feature = MassErrorDaFeature(residue_masses=residue_masses)
-        metadata = pd.DataFrame(
-            {
-                "precursor_mz": [500.503638],
-                "precursor_charge": [2],
-                "prediction": ["invalid_string"],
-            }
-        )
-        dataset = CalibrationDataset(metadata=metadata, predictions=None)
-
-        with pytest.raises(ValueError, match="not valid peptide sequences"):
-            feature.compute(dataset)
 
     def test_custom_residue_masses(self):
         """Test that custom residue masses are used correctly."""

--- a/tests/calibration/test_calibrator.py
+++ b/tests/calibration/test_calibrator.py
@@ -69,7 +69,11 @@ class TestProbabilityCalibrator:
     def sample_dataset(self):
         """Create a sample CalibrationDataset for testing."""
         metadata = pd.DataFrame(
-            {"confidence": [0.9, 0.8, 0.7, 0.6, 0.5], "other_col": [1, 2, 3, 4, 5]}
+            {
+                "confidence": [0.9, 0.8, 0.7, 0.6, 0.5],
+                "prediction": [["A"], ["G"], ["S"], ["V"], ["P"]],
+                "other_col": [1, 2, 3, 4, 5],
+            }
         )
         return CalibrationDataset(metadata=metadata, predictions=[None] * 5)
 
@@ -84,6 +88,7 @@ class TestProbabilityCalibrator:
         metadata = pd.DataFrame(
             {
                 "confidence": np.random.uniform(0.1, 0.99, n_samples),
+                "prediction": [["A", "G"]] * n_samples,
                 "correct": np.random.choice([0, 1], n_samples),
                 "feature1": np.random.uniform(1.0, 10.0, n_samples),
                 "feature2": np.random.uniform(0.1, 1.0, n_samples),
@@ -285,6 +290,7 @@ class TestProbabilityCalibrator:
                         np.random.uniform(0.1, 0.99, n_unlabelled),
                     ]
                 ),
+                "prediction": [["A", "G"]] * (n_labelled + n_unlabelled),
                 "sequence": [["A", "G"]] * n_labelled + [None] * n_unlabelled,
                 "valid_sequence": [True] * n_labelled + [False] * n_unlabelled,
                 "correct": np.concatenate(
@@ -304,11 +310,22 @@ class TestProbabilityCalibrator:
 
         assert calibrator.scaler.n_samples_seen_ == n_labelled
 
+    def test_fit_rejects_raw_proforma_string_ground_truth(self, labelled_dataset):
+        """Raw ProForma strings are rejected at CalibrationDataset construction."""
+        metadata = labelled_dataset.metadata.copy()
+        metadata["sequence"] = ["AG"] * len(metadata)
+        with pytest.raises(ValueError, match="raw strings"):
+            CalibrationDataset(
+                metadata=metadata,
+                predictions=labelled_dataset.predictions,
+            )
+
     def test_fit_raises_when_no_valid_ground_truth_sequences(self, calibrator):
         metadata = pd.DataFrame(
             {
                 "confidence": [0.9, 0.8],
-                "sequence": [None, []],
+                "prediction": [["A"], ["G"]],
+                "sequence": [None, None],
                 "valid_sequence": [False, False],
                 "correct": [0, 0],
             }
@@ -361,7 +378,7 @@ class TestProbabilityCalibrator:
 
     def test_empty_dataset_handling(self, calibrator):
         """Test handling of empty datasets."""
-        empty_metadata = pd.DataFrame({"confidence": []})  # Include confidence column
+        empty_metadata = pd.DataFrame({"confidence": [], "prediction": []})
         empty_dataset = CalibrationDataset(metadata=empty_metadata, predictions=[])
 
         feature = MockCalibrationFeature("test_feature")

--- a/tests/calibration/test_diagnostics.py
+++ b/tests/calibration/test_diagnostics.py
@@ -10,7 +10,6 @@ from winnow.calibration.diagnostics import (
     SEQUENCE_LABEL_COLUMN,
     DiagnosticArrays,
     TailSlice,
-    compute_correct_from_sequence,
     empirical_stece,
     filter_tail,
     fit_isotonic_calibration,
@@ -22,7 +21,13 @@ from winnow.calibration.diagnostics import (
 )
 from winnow.datasets.calibration_dataset import CalibrationDataset
 
-RESIDUE_MASSES = {"A": 71.037114, "G": 57.021464}
+
+def _token_prediction_frame(**columns: object) -> pd.DataFrame:
+    """Build metadata that satisfies CalibrationDataset peptide structure checks."""
+    frame = pd.DataFrame(columns)
+    if "prediction" not in frame.columns:
+        frame["prediction"] = [["A"]] * len(frame)
+    return frame
 
 
 class TestValidateLabelConfig:
@@ -53,76 +58,65 @@ class TestValidateLabelConfig:
         validate_label_config(label_source, label_column)
 
 
-class TestComputeCorrectFromSequence:
-    @pytest.mark.parametrize(
-        ("sequence", "prediction", "expected"),
-        [
-            ([["A", "G"], ["A"]], [["A", "G"], ["G"]], [True, False]),
-            (
-                [np.array(["A", "G"], dtype=object)],
-                [np.array(["A", "G"], dtype=object)],
-                [True],
-            ),
-        ],
-    )
-    def test_sequence_correctness(
-        self, sequence: object, prediction: object, expected: list[bool]
-    ) -> None:
-        meta = pd.DataFrame({"sequence": sequence, "prediction": prediction})
-        correct = compute_correct_from_sequence(meta, RESIDUE_MASSES)
-        assert correct.tolist() == expected
-
-    def test_absent_sequences_marked_incorrect(self) -> None:
-        meta = pd.DataFrame(
-            {
-                "sequence": [["A", "G"], None, []],
-                "prediction": [["A", "G"], ["A", "G"], ["A", "G"]],
-            }
-        )
-        correct = compute_correct_from_sequence(meta, RESIDUE_MASSES)
-        assert correct.tolist() == [True, False, False]
-
-
 class TestResolveDiagnosticsLabels:
     def test_precomputed_reads_column(self) -> None:
-        meta = pd.DataFrame({"proteome_hit": [True, False, True]})
+        meta = _token_prediction_frame(proteome_hit=[True, False, True])
         labels, column = resolve_diagnostics_labels(
             CalibrationDataset(metadata=meta),
             "precomputed",
             "proteome_hit",
-            residue_masses=RESIDUE_MASSES,
         )
         assert column == "proteome_hit"
         assert labels.tolist() == [True, False, True]
 
-    def test_sequence_uses_derived_correct_column(self) -> None:
-        meta = pd.DataFrame(
-            {
-                "sequence": [["A"], ["A"]],
-                "prediction": [["A"], ["G"]],
-            }
+    def test_sequence_uses_finalised_correct_column(self) -> None:
+        meta = _token_prediction_frame(
+            sequence=[["A"], ["A"]],
+            prediction=[["A"], ["G"]],
+            correct=[True, False],
+            valid_sequence=[True, True],
         )
         labels, column = resolve_diagnostics_labels(
             CalibrationDataset(metadata=meta),
             "sequence",
             None,
-            residue_masses=RESIDUE_MASSES,
         )
         assert column == SEQUENCE_LABEL_COLUMN
         assert labels.tolist() == [True, False]
 
-    def test_sequence_excludes_invalid_sequence_rows(self) -> None:
+    def test_sequence_rejects_raw_proforma_strings(self) -> None:
         meta = pd.DataFrame(
             {
-                "sequence": [["A"], None],
-                "prediction": [["A"], ["G"]],
+                "sequence": ["AG", "AG"],
+                "prediction": ["AG", "AA"],
             }
+        )
+        with pytest.raises(ValueError, match="raw strings"):
+            CalibrationDataset(metadata=meta)
+
+    def test_sequence_requires_finalised_correct(self) -> None:
+        meta = _token_prediction_frame(
+            sequence=[["A"], ["A"]],
+            prediction=[["A"], ["G"]],
+        )
+        with pytest.raises(ValueError, match="finalised labelled metadata"):
+            resolve_diagnostics_labels(
+                CalibrationDataset(metadata=meta),
+                "sequence",
+                None,
+            )
+
+    def test_sequence_excludes_invalid_sequence_rows(self) -> None:
+        meta = _token_prediction_frame(
+            sequence=[["A"], None],
+            prediction=[["A"], ["G"]],
+            correct=[True, False],
+            valid_sequence=[True, False],
         )
         labels, column = resolve_diagnostics_labels(
             CalibrationDataset(metadata=meta),
             "sequence",
             None,
-            residue_masses=RESIDUE_MASSES,
         )
         assert column == SEQUENCE_LABEL_COLUMN
         assert labels.tolist() == [True]
@@ -131,26 +125,22 @@ class TestResolveDiagnosticsLabels:
     def test_precomputed_missing_column_raises(self) -> None:
         with pytest.raises(ValueError, match="not found"):
             resolve_diagnostics_labels(
-                CalibrationDataset(metadata=pd.DataFrame({"confidence": [0.5]})),
+                CalibrationDataset(metadata=_token_prediction_frame(confidence=[0.5])),
                 "precomputed",
                 "proteome_hit",
-                residue_masses=RESIDUE_MASSES,
             )
 
     def test_precomputed_string_labels_raises(self) -> None:
         with pytest.raises(ValueError, match="must be a boolean or numeric series"):
             resolve_diagnostics_labels(
                 CalibrationDataset(
-                    metadata=pd.DataFrame(
-                        {
-                            "confidence": [0.5, 0.7, 0.6],
-                            "proteome_hit": ["True", "False", "True"],
-                        }
+                    metadata=_token_prediction_frame(
+                        confidence=[0.5, 0.7, 0.6],
+                        proteome_hit=["True", "False", "True"],
                     )
                 ),
                 "precomputed",
                 "proteome_hit",
-                residue_masses=RESIDUE_MASSES,
             )
 
 

--- a/tests/datasets/data_loaders/test_utils.py
+++ b/tests/datasets/data_loaders/test_utils.py
@@ -153,16 +153,17 @@ class TestNormalizePeptideCell:
 
 
 class TestLabelledTrainingMask:
-    def test_imputes_valid_sequence_from_sequence(self):
+    def test_requires_valid_sequence_when_sequence_present(self):
         metadata = pd.DataFrame({"sequence": [["A"], None, ["B"]]})
-        assert utils.labelled_training_mask(metadata).tolist() == [True, False, True]
-        assert metadata["valid_sequence"].tolist() == [True, False, True]
+        with pytest.raises(ValueError, match="valid_sequence"):
+            utils.labelled_training_mask(metadata)
 
     def test_uses_existing_valid_sequence_column(self):
         metadata = pd.DataFrame(
             {"valid_sequence": [True, False, True], "sequence": [["A"], None, ["B"]]}
         )
         assert utils.labelled_training_mask(metadata).tolist() == [True, False, True]
+        assert "valid_sequence" in metadata.columns
 
     def test_require_labelled_rows_raises_when_empty(self):
         metadata = pd.DataFrame(

--- a/tests/datasets/data_loaders/test_winnow.py
+++ b/tests/datasets/data_loaders/test_winnow.py
@@ -100,6 +100,16 @@ class TestWinnowDatasetLoader:
         assert isinstance(dataset.metadata["sequence"].iloc[0], list)
         assert dataset.metadata["sequence"].iloc[0] == ["A", "G"]
 
+    def test_labelled_reload_computes_correct_and_num_matches(
+        self, loader, metadata_dir_with_sequence
+    ):
+        """Reload finalisation writes match labels for annotated metadata."""
+        dataset = loader.load(data_path=metadata_dir_with_sequence)
+        assert dataset.metadata["valid_prediction"].tolist() == [True, True]
+        assert dataset.metadata["valid_sequence"].tolist() == [True, True]
+        assert dataset.metadata["correct"].tolist() == [True, True]
+        assert dataset.metadata["num_matches"].tolist() == [2, 2]
+
     def test_mz_array_parsed_comma_format(self, loader, metadata_dir):
         """mz_array written with commas should be parsed to a Python list."""
         dataset = loader.load(data_path=metadata_dir)

--- a/tests/datasets/test_calibration_dataset.py
+++ b/tests/datasets/test_calibration_dataset.py
@@ -328,6 +328,59 @@ class TestCalibrationDataset:
         assert "valid_sequence" not in saved_df.columns
         assert "valid_prediction" not in saved_df.columns
 
+    def test_format_metadata_for_export(self):
+        """Test export formatting converts peptides and drops internal columns."""
+        metadata = pd.DataFrame(
+            {
+                "confidence": [0.9, 0.8, 0.7],
+                "prediction": [
+                    ["[UNIMOD:1]", "P", "E", "P", "T", "I", "D", "E"],
+                    ["M[UNIMOD:35]", "P", "E", "P", "T", "I", "D", "E"],
+                    ["P", "E", "P", "T", "I", "D", "E", "[UNIMOD:2]"],
+                ],
+                "sequence": [
+                    ["P", "E", "P", "T", "I", "D", "E"],
+                    ["M[UNIMOD:35]", "P", "E", "P", "T", "I", "D", "E"],
+                    ["P", "E", "P", "T", "I", "D", "E", "[UNIMOD:2]"],
+                ],
+                "prediction_untokenised": [
+                    "[UNIMOD:1]-PEPTIDE",
+                    "M[UNIMOD:35]PEPTIDE",
+                    "PEPTIDE-[UNIMOD:2]",
+                ],
+            }
+        )
+        dataset = CalibrationDataset(metadata=metadata, predictions=None)
+
+        formatted = dataset.format_metadata_for_export()
+
+        assert "valid_sequence" not in formatted.columns
+        assert "valid_prediction" not in formatted.columns
+        assert "prediction_untokenised" not in formatted.columns
+        assert formatted["prediction"].tolist() == [
+            "[UNIMOD:1]-PEPTIDE",
+            "M[UNIMOD:35]PEPTIDE",
+            "PEPTIDE-[UNIMOD:2]",
+        ]
+        assert formatted["sequence"].tolist() == [
+            "PEPTIDE",
+            "M[UNIMOD:35]PEPTIDE",
+            "PEPTIDE-[UNIMOD:2]",
+        ]
+        # Original dataset remains tokenised / unmutated
+        assert dataset.metadata["prediction"].iloc[0] == [
+            "[UNIMOD:1]",
+            "P",
+            "E",
+            "P",
+            "T",
+            "I",
+            "D",
+            "E",
+        ]
+        assert "valid_prediction" in dataset.metadata.columns
+        assert "prediction_untokenised" in dataset.metadata.columns
+
     def test_length_consistency(self, calibration_dataset):
         """Test that length is consistent between metadata and predictions."""
         # This should not raise an assertion error

--- a/tests/datasets/test_calibration_dataset.py
+++ b/tests/datasets/test_calibration_dataset.py
@@ -383,17 +383,17 @@ class TestCalibrationDataset:
 
     def test_length_consistency(self, calibration_dataset):
         """Test that length is consistent between metadata and predictions."""
-        # This should not raise an assertion error
+        # This should not raise an error
         assert len(calibration_dataset) == len(calibration_dataset.metadata)
         assert len(calibration_dataset) == len(calibration_dataset.predictions)
 
     def test_length_inconsistency_raises_error(self, sample_metadata):
-        """Test that length inconsistency raises assertion error."""
+        """Test that length inconsistency raises ValueError."""
         # Create mismatched lengths
         short_predictions = [None, None]  # Only 2 predictions for 5 metadata rows
 
         with pytest.raises(
-            AssertionError, match="Length of metadata and predictions must match"
+            ValueError, match="Length of metadata and predictions must match"
         ):
             CalibrationDataset(metadata=sample_metadata, predictions=short_predictions)
 

--- a/tests/datasets/test_calibration_dataset.py
+++ b/tests/datasets/test_calibration_dataset.py
@@ -257,7 +257,8 @@ class TestCalibrationDataset:
         """Test that accessing beam[0] on empty beam raises helpful error."""
         # Create a dataset with an empty beam (empty list instead of None)
         empty_beam_dataset = CalibrationDataset(
-            metadata=pd.DataFrame({"confidence": [0.5]}), predictions=[[]]
+            metadata=pd.DataFrame({"confidence": [0.5], "prediction": [["A"]]}),
+            predictions=[[]],
         )
         with pytest.raises(ValueError, match="beam is empty"):
             empty_beam_dataset.filter_entries(
@@ -272,7 +273,7 @@ class TestCalibrationDataset:
         """Test that accessing beam[1] when beam has only 1 element raises helpful error."""
         # Create a dataset with a beam that has only 1 element
         short_beam_dataset = CalibrationDataset(
-            metadata=pd.DataFrame({"confidence": [0.5]}),
+            metadata=pd.DataFrame({"confidence": [0.5], "prediction": [["A"]]}),
             predictions=[[MockScoredSequence(["A"], np.log(0.8))]],
         )
         with pytest.raises(ValueError, match="too short"):
@@ -284,7 +285,10 @@ class TestCalibrationDataset:
 
     def test_filter_entries_handles_empty_dataset(self):
         """Test that filtering an empty dataset returns an empty dataset."""
-        empty_dataset = CalibrationDataset(metadata=pd.DataFrame(), predictions=[])
+        empty_dataset = CalibrationDataset(
+            metadata=pd.DataFrame({"prediction": pd.Series(dtype=object)}),
+            predictions=[],
+        )
         filtered = empty_dataset.filter_entries(lambda row: True)
         assert len(filtered) == 0
 
@@ -342,7 +346,7 @@ class TestCalibrationDataset:
 
     def test_empty_dataset(self):
         """Test operations on empty dataset."""
-        empty_metadata = pd.DataFrame()
+        empty_metadata = pd.DataFrame({"prediction": pd.Series(dtype=object)})
         empty_dataset = CalibrationDataset(metadata=empty_metadata, predictions=[])
 
         assert len(empty_dataset) == 0
@@ -422,7 +426,7 @@ class TestCalibrationDataset:
 
     def test_predictions_none_default(self):
         """Test that predictions defaults to None."""
-        metadata = pd.DataFrame({"confidence": [0.9]})
+        metadata = pd.DataFrame({"confidence": [0.9], "prediction": [["A"]]})
         dataset = CalibrationDataset(metadata=metadata)
 
         assert dataset.predictions is None

--- a/tests/datasets/test_calibration_dataset_peptide_contract.py
+++ b/tests/datasets/test_calibration_dataset_peptide_contract.py
@@ -1,0 +1,103 @@
+"""Unit tests for CalibrationDataset peptide structure validation."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from winnow.datasets.calibration_dataset import CalibrationDataset
+
+
+class TestCalibrationDatasetPeptideContract:
+    def test_requires_prediction_column(self) -> None:
+        with pytest.raises(ValueError, match="requires a 'prediction' column"):
+            CalibrationDataset(metadata=pd.DataFrame({"confidence": [0.9]}))
+
+    def test_rejects_raw_prediction_strings(self) -> None:
+        with pytest.raises(ValueError, match="raw strings"):
+            CalibrationDataset(
+                metadata=pd.DataFrame(
+                    {"confidence": [0.9], "prediction": ["AG"]},
+                )
+            )
+
+    def test_normalises_empty_prediction_containers_to_none(self) -> None:
+        dataset = CalibrationDataset(
+            metadata=pd.DataFrame(
+                {"confidence": [0.9], "prediction": [[]]},
+            )
+        )
+        assert dataset.metadata["prediction"].tolist() == [None]
+        assert dataset.metadata["valid_prediction"].tolist() == [False]
+
+    def test_normalises_empty_sequence_containers_to_none(self) -> None:
+        dataset = CalibrationDataset(
+            metadata=pd.DataFrame(
+                {
+                    "confidence": [0.9],
+                    "prediction": [["A", "G"]],
+                    "sequence": [[]],
+                }
+            )
+        )
+        assert dataset.metadata["sequence"].tolist() == [None]
+        assert dataset.metadata["valid_sequence"].tolist() == [False]
+
+    def test_rejects_unsupported_prediction_values(self) -> None:
+        with pytest.raises(ValueError, match="unsupported value"):
+            CalibrationDataset(
+                metadata=pd.DataFrame(
+                    {"confidence": [0.9], "prediction": [42]},
+                )
+            )
+
+    def test_accepts_token_lists_and_derives_valid_prediction(self) -> None:
+        dataset = CalibrationDataset(
+            metadata=pd.DataFrame(
+                {
+                    "confidence": [0.9, 0.8],
+                    "prediction": [["A", "G"], None],
+                }
+            )
+        )
+        assert dataset.metadata["valid_prediction"].tolist() == [True, False]
+
+    def test_derives_valid_sequence_when_labelled(self) -> None:
+        dataset = CalibrationDataset(
+            metadata=pd.DataFrame(
+                {
+                    "confidence": [0.9, 0.8],
+                    "prediction": [["A", "G"], ["A", "G"]],
+                    "sequence": [["A", "G"], None],
+                }
+            )
+        )
+        assert dataset.metadata["valid_sequence"].tolist() == [True, False]
+        assert dataset.metadata["valid_prediction"].tolist() == [True, True]
+
+    def test_overwrites_stale_valid_prediction_with_warning(self) -> None:
+        with pytest.warns(UserWarning, match="valid_prediction"):
+            dataset = CalibrationDataset(
+                metadata=pd.DataFrame(
+                    {
+                        "confidence": [0.9],
+                        "prediction": [["A", "G"]],
+                        "valid_prediction": [False],
+                    }
+                )
+            )
+        assert dataset.metadata["valid_prediction"].tolist() == [True]
+
+    def test_overwrites_stale_valid_sequence_with_warning(self) -> None:
+        with pytest.warns(UserWarning, match="valid_sequence"):
+            dataset = CalibrationDataset(
+                metadata=pd.DataFrame(
+                    {
+                        "confidence": [0.9],
+                        "prediction": [["A", "G"]],
+                        "sequence": [["A", "G"]],
+                        "valid_sequence": [False],
+                    }
+                )
+            )
+        assert dataset.metadata["valid_sequence"].tolist() == [True]

--- a/tests/fdr/test_database_grounded.py
+++ b/tests/fdr/test_database_grounded.py
@@ -80,7 +80,7 @@ class TestDatabaseGroundedFDRControl:
                 }
             )
         )
-        with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
+        with pytest.raises(ValueError, match="Fit method requires non-empty data"):
             db_fdr_control.fit(empty_data)
 
     def test_fit_requires_finalised_metadata(self, db_fdr_control):

--- a/tests/fdr/test_database_grounded.py
+++ b/tests/fdr/test_database_grounded.py
@@ -2,7 +2,12 @@
 
 import pytest
 import pandas as pd
+from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.fdr.database_grounded import DatabaseGroundedFDRControl
+
+
+def _as_dataset(df: pd.DataFrame) -> CalibrationDataset:
+    return CalibrationDataset(metadata=df)
 
 
 class TestDatabaseGroundedFDRControl:
@@ -11,33 +16,18 @@ class TestDatabaseGroundedFDRControl:
     @pytest.fixture()
     def db_fdr_control(self):
         """Create a DatabaseGroundedFDRControl instance for testing."""
-        residue_masses = {
-            "G": 57.021464,
-            "A": 71.037114,
-            "P": 97.052764,
-            "E": 129.042593,
-            "T": 101.047670,
-            "I": 113.084064,
-            "D": 115.026943,
-            "R": 156.101111,
-            "O": 237.147727,
-            "N": 114.042927,
-            "S": 87.032028,
-            "M": 131.040485,
-            "L": 113.084064,
-        }
-        return DatabaseGroundedFDRControl(
-            confidence_feature="confidence", residue_masses=residue_masses
-        )
+        return DatabaseGroundedFDRControl(confidence_feature="confidence", drop=0)
 
     @pytest.fixture()
     def sample_dataset_df(self):
-        """Create a sample dataset DataFrame for testing."""
+        """Finalised sample dataset DataFrame for testing."""
         return pd.DataFrame(
             {
-                "sequence": ["PEPTIDE", "PROTEIN", "SAMPLE"],
-                "prediction": ["PEPTIDE", "PROTIEN", "SAMPL"],  # One mismatch
+                "sequence": [list("PEPTIDE"), list("PROTEIN"), list("SAMPLE")],
+                "prediction": [list("PEPTIDE"), list("PROTIEN"), list("SAMPL")],
                 "confidence": [0.9, 0.8, 0.7],
+                "correct": [True, False, False],
+                "valid_sequence": [True, True, True],
                 "precursor_mz": [500.504, 400.672, 400.504],
                 "precursor_charge": [2, 3, 2],
             }
@@ -51,14 +41,8 @@ class TestDatabaseGroundedFDRControl:
 
     def test_fit_basic(self, db_fdr_control, sample_dataset_df):
         """Test basic fitting functionality."""
-        # Convert sequences to list format as expected by the implementation
-        sample_dataset_df = sample_dataset_df.copy()
-        sample_dataset_df["prediction"] = sample_dataset_df["prediction"].apply(list)
+        db_fdr_control.fit(_as_dataset(sample_dataset_df))
 
-        # Should not raise an exception
-        db_fdr_control.fit(sample_dataset_df)
-
-        # Check that fit created the required attributes
         assert hasattr(db_fdr_control, "preds")
         assert hasattr(db_fdr_control, "_fdr_values")
         assert hasattr(db_fdr_control, "_confidence_scores")
@@ -68,75 +52,86 @@ class TestDatabaseGroundedFDRControl:
     def test_fit_with_parameters(self, db_fdr_control):
         """Test fit with custom parameters."""
         sample_df = pd.DataFrame(
-            {"sequence": ["TEST"], "prediction": [list("TEST")], "confidence": [0.9]}
+            {
+                "sequence": [list("TEST")],
+                "prediction": [list("TEST")],
+                "confidence": [0.9],
+                "correct": [True],
+                "valid_sequence": [True],
+            }
         )
 
-        db_fdr_control.fit(sample_df)
+        db_fdr_control.fit(_as_dataset(sample_df))
 
-        # Check that fit created the required attributes
         assert hasattr(db_fdr_control, "preds")
         assert len(db_fdr_control.preds) == 1
         assert db_fdr_control.preds.iloc[0]["confidence"] == 0.9
 
     def test_fit_with_empty_data(self, db_fdr_control):
         """Test that fit method handles empty data."""
-        empty_data = pd.DataFrame()
+        empty_data = _as_dataset(
+            pd.DataFrame(
+                {
+                    "prediction": pd.Series([], dtype=object),
+                    "sequence": pd.Series([], dtype=object),
+                    "correct": pd.Series([], dtype=bool),
+                    "valid_sequence": pd.Series([], dtype=bool),
+                    "confidence": pd.Series([], dtype=float),
+                }
+            )
+        )
         with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
             db_fdr_control.fit(empty_data)
 
-    def test_fit_imputes_valid_sequence_correct_and_num_matches(self, db_fdr_control):
-        """Sequence-derived fit imputes validity and per-row labels on all rows."""
-        dataset = pd.DataFrame(
-            {
-                "sequence": [list("PEPTIDE"), None, []],
-                "prediction": [list("PEPTIDE"), list("AG"), list("AG")],
-                "confidence": [0.9, 0.8, 0.7],
-            }
+    def test_fit_requires_finalised_metadata(self, db_fdr_control):
+        """Fit refuses metadata missing loader-derived correctness labels."""
+        dataset = _as_dataset(
+            pd.DataFrame(
+                {
+                    "sequence": [list("PEPTIDE")],
+                    "prediction": [list("PEPTIDE")],
+                    "confidence": [0.9],
+                }
+            )
         )
-        db_fdr_control.fit(dataset)
-
-        assert dataset["valid_sequence"].tolist() == [True, False, False]
-        assert db_fdr_control.preds["correct"].tolist() == [True, False, False]
-        assert dataset["num_matches"].tolist() == [7, 0, 0]
+        with pytest.raises(ValueError, match="finalised labelled metadata"):
+            db_fdr_control.fit(dataset)
 
     def test_fit_excludes_invalid_sequence_rows_from_fdr_curve(self):
         """Rows with valid_sequence=False must not enter the precision curve."""
-        ctrl = DatabaseGroundedFDRControl(
-            confidence_feature="confidence",
-            residue_masses={
-                "P": 97.052764,
-                "E": 129.042593,
-                "T": 101.047670,
-                "I": 113.084064,
-                "D": 115.026943,
-            },
-            drop=0,
-        )
-        dataset = pd.DataFrame(
-            {
-                "sequence": [list("PEPTIDE"), None],
-                "prediction": [list("PEPTIDE"), list("WRONG")],
-                "confidence": [0.9, 0.99],
-            }
+        ctrl = DatabaseGroundedFDRControl(confidence_feature="confidence", drop=0)
+        dataset = _as_dataset(
+            pd.DataFrame(
+                {
+                    "sequence": [list("PEPTIDE"), None],
+                    "prediction": [list("PEPTIDE"), list("WRONG")],
+                    "confidence": [0.9, 0.99],
+                    "correct": [True, False],
+                    "valid_sequence": [True, False],
+                }
+            )
         )
         ctrl.fit(dataset)
         assert ctrl._fdr_values.tolist() == [0.0]
         assert ctrl._confidence_scores.tolist() == [0.9]
 
     def test_fit_raises_when_no_valid_ground_truth_sequences(self, db_fdr_control):
-        dataset = pd.DataFrame(
-            {
-                "sequence": [None, []],
-                "prediction": [list("AG"), list("AG")],
-                "confidence": [0.9, 0.8],
-            }
+        dataset = _as_dataset(
+            pd.DataFrame(
+                {
+                    "sequence": [None, None],
+                    "prediction": [list("AG"), list("AG")],
+                    "confidence": [0.9, 0.8],
+                    "correct": [False, False],
+                    "valid_sequence": [False, False],
+                }
+            )
         )
         with pytest.raises(ValueError, match="valid_sequence=True"):
             db_fdr_control.fit(dataset)
 
     def test_get_confidence_cutoff_requires_fitting(self, db_fdr_control):
         """Test that get_confidence_cutoff requires fitting first."""
-        # Should raise AttributeError if not fitted
         with pytest.raises(
             AttributeError, match=r"FDR method not fitted, please call `fit\(\)` first"
         ):
@@ -144,7 +139,6 @@ class TestDatabaseGroundedFDRControl:
 
     def test_compute_fdr_requires_fitting(self, db_fdr_control):
         """Test that compute_fdr requires fitting first."""
-        # Should raise AttributeError if not fitted
         with pytest.raises(
             AttributeError, match=r"FDR method not fitted, please call `fit\(\)` first"
         ):

--- a/tests/fdr/test_nonparametric.py
+++ b/tests/fdr/test_nonparametric.py
@@ -16,9 +16,10 @@ class TestNonParametricFDRControl:
 
     @pytest.fixture()
     def sample_confidence_data(self):
-        """Create sample confidence data for testing."""
-        return pd.DataFrame(
-            {"confidence": [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]}
+        """Create sample confidence scores for testing."""
+        return pd.Series(
+            [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1],
+            name="confidence",
         )
 
     @pytest.fixture()
@@ -51,7 +52,7 @@ class TestNonParametricFDRControl:
 
     def test_fit_with_single_value(self, nonparametric_fdr_control):
         """Test fitting with a single confidence value."""
-        single_data = pd.DataFrame({"confidence": [0.8]})
+        single_data = pd.Series([0.8], name="confidence")
         nonparametric_fdr_control.fit(single_data)
 
         assert len(nonparametric_fdr_control._confidence_scores) == 1
@@ -59,14 +60,17 @@ class TestNonParametricFDRControl:
 
     def test_fit_with_duplicate_values(self, nonparametric_fdr_control):
         """Test fitting with duplicate confidence values."""
-        duplicate_data = pd.DataFrame({"confidence": [0.9, 0.8, 0.8, 0.7, 0.7, 0.6]})
+        duplicate_data = pd.Series(
+            [0.9, 0.8, 0.8, 0.7, 0.7, 0.6],
+            name="confidence",
+        )
         nonparametric_fdr_control.fit(duplicate_data)
 
         assert len(nonparametric_fdr_control._confidence_scores) == 6
 
     def test_fit_with_empty_data(self, nonparametric_fdr_control):
         """Test that fit method handles empty data."""
-        empty_data = pd.DataFrame({"confidence": []})
+        empty_data = pd.Series([], dtype=float, name="confidence")
         with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
             nonparametric_fdr_control.fit(empty_data)
 

--- a/tests/fdr/test_nonparametric.py
+++ b/tests/fdr/test_nonparametric.py
@@ -71,7 +71,7 @@ class TestNonParametricFDRControl:
     def test_fit_with_empty_data(self, nonparametric_fdr_control):
         """Test that fit method handles empty data."""
         empty_data = pd.Series([], dtype=float, name="confidence")
-        with pytest.raises(AssertionError, match="Fit method requires non-empty data"):
+        with pytest.raises(ValueError, match="Fit method requires non-empty data"):
             nonparametric_fdr_control.fit(empty_data)
 
     def test_get_confidence_cutoff_requires_fitting(self, nonparametric_fdr_control):

--- a/winnow/calibration/calibrator.py
+++ b/winnow/calibration/calibrator.py
@@ -216,9 +216,12 @@ class ProbabilityCalibrator:
 
         This method computes the features from the dataset, prepares the labels, and trains an MLP classifier for recalibrating probabilities.
 
-        Only rows with a valid ground-truth sequence (``valid_sequence=True``, derived
-        from ``sequence`` when needed) contribute to scaler and classifier fitting;
-        all rows still receive feature computation and retain their ``correct`` labels.
+        Only rows with a valid ground-truth sequence (``valid_sequence=True``)
+        contribute to scaler and classifier fitting. The dataset must already
+        contain finalised metadata from a DatasetLoader (tokenised peptides and,
+        for labelled data, ``valid_sequence`` / ``correct``); this method does not
+        tokenise sequences itself. All rows still receive feature computation and
+        retain their ``correct`` labels.
 
         Args:
             dataset (CalibrationDataset): The dataset used for training the classifier.

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -10,16 +10,11 @@ from typing import Literal, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype
-from instanovo.utils.metrics import Metrics
-from instanovo.utils.residues import ResidueSet
 from numpy.typing import NDArray
 from sklearn.isotonic import IsotonicRegression
 
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.datasets.data_loaders.utils import (
-    finalize_peptide_metadata,
-    require_labelled_rows,
-)
+from winnow.datasets.data_loaders.utils import require_labelled_rows
 
 LabelSource = Literal["sequence", "precomputed"]
 SEQUENCE_LABEL_COLUMN = "correct"
@@ -94,37 +89,6 @@ def validate_label_config(
         )
 
 
-def compute_correct_from_sequence(
-    metadata: pd.DataFrame,
-    residue_masses: dict[str, float],
-    residue_remapping: Optional[dict[str, str]] = None,
-) -> pd.Series:
-    """Derive full-sequence correctness from sequence and prediction columns."""
-    if "sequence" not in metadata.columns:
-        raise ValueError(
-            "label_source='sequence' requires a 'sequence' column in the dataset."
-        )
-    if "prediction" not in metadata.columns:
-        raise ValueError(
-            "label_source='sequence' requires a 'prediction' column in the dataset."
-        )
-
-    metrics = Metrics(
-        residue_set=ResidueSet(
-            residue_masses=residue_masses,
-            residue_remapping=residue_remapping or {},
-        )
-    )
-    df = metadata.copy()
-    finalize_peptide_metadata(
-        df,
-        metrics,
-        has_labels=True,
-        residue_remapping=residue_remapping or {},
-    )
-    return df["correct"]
-
-
 def _coerce_bool_labels(series: pd.Series, column: str) -> pd.Series:
     if series.isna().any():
         raise ValueError(
@@ -143,10 +107,12 @@ def resolve_diagnostics_labels(
     dataset: CalibrationDataset,
     label_source: LabelSource,
     label_column: Optional[str],
-    residue_masses: dict[str, float],
-    residue_remapping: Optional[dict[str, str]] = None,
 ) -> Tuple[pd.Series, str]:
-    """Resolve boolean labels and return (labels, resolved_column_name)."""
+    """Resolve boolean labels and return (labels, resolved_column_name).
+
+    For ``label_source='sequence'``, the dataset must already contain finalised
+    ``correct`` and ``valid_sequence`` columns from a DatasetLoader.
+    """
     metadata = dataset.metadata
 
     if label_source == "precomputed":
@@ -159,9 +125,17 @@ def resolve_diagnostics_labels(
         labels = _coerce_bool_labels(metadata[label_column], label_column)
         return labels, label_column
 
-    if "correct" not in metadata.columns:
-        metadata["correct"] = compute_correct_from_sequence(
-            metadata, residue_masses, residue_remapping
+    missing = [
+        column
+        for column in ("correct", "valid_sequence")
+        if column not in metadata.columns
+    ]
+    if missing:
+        raise ValueError(
+            "This operation requires finalised labelled metadata with "
+            f"{', '.join(repr(c) for c in missing)}. "
+            "Load labelled data through a DatasetLoader before fitting/running "
+            "diagnostics."
         )
     mask = require_labelled_rows(metadata, context="Sequence-derived diagnostics")
     labels = metadata.loc[mask, "correct"].astype(bool)

--- a/winnow/calibration/diagnostics.py
+++ b/winnow/calibration/diagnostics.py
@@ -81,7 +81,6 @@ def validate_label_config(
     if label_source == "sequence" and label_column is not None:
         raise ValueError(
             "diagnostics.label_column must not be set when label_source is 'sequence'. "
-            "Sequence-derived labels are written to the 'correct' column automatically."
         )
     if label_source == "precomputed" and not label_column:
         raise ValueError(

--- a/winnow/calibration/features/retention_time.py
+++ b/winnow/calibration/features/retention_time.py
@@ -10,7 +10,7 @@ from sklearn.linear_model import LinearRegression
 
 from winnow.calibration.features.base import CalibrationFeatures, FeatureDependency
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.utils.peptide import tokens_to_proforma
+from winnow.utils.peptide import as_token_list, tokens_to_proforma
 
 
 class RetentionTimeFeature(CalibrationFeatures):
@@ -104,14 +104,14 @@ class RetentionTimeFeature(CalibrationFeatures):
     @staticmethod
     def _sequence_key(row: pd.Series) -> tuple:
         """Hashable key for a predicted peptide sequence."""
-        prediction = row["prediction"]
-        if isinstance(prediction, list):
-            return tuple(prediction)
+        tokens = as_token_list(row["prediction"])
+        if tokens is not None:
+            return tuple(tokens)
         if "prediction_untokenised" in row.index and pd.notna(
             row.get("prediction_untokenised")
         ):
             return (str(row["prediction_untokenised"]),)
-        return (str(prediction),)
+        return (str(row["prediction"]),)
 
     def check_valid_irt_prediction(self, dataset: CalibrationDataset) -> pd.Series:
         """Check which predictions are valid for iRT prediction.

--- a/winnow/configs/fdr_method/database_grounded.yaml
+++ b/winnow/configs/fdr_method/database_grounded.yaml
@@ -3,6 +3,4 @@
 _target_: winnow.fdr.database_grounded.DatabaseGroundedFDRControl
 
 confidence_feature: ${fdr_control.confidence_column}  # Name of the column with confidence scores to use for FDR estimation.
-residue_masses: ${residue_masses}  # The residue masses from global `residues` config
-isotope_error_range: [0, 1]  # The isotope error range for matching peptides
 drop: 10  # The number of top predictions to drop for stability

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 from winnow.compat.instanovo import ScoredSequence
 from winnow.utils.peptide import (
-    _is_missing_cell,
+    is_missing_cell,
     as_token_list,
     is_usable_peptide_label,
     is_valid_peptide_tokens,
@@ -38,7 +38,7 @@ def _normalise_and_validate_peptide_column(
 ) -> None:
     """Normalise empty containers to None and reject unsupported peptide cells."""
     for index, value in metadata[column].items():
-        if _is_missing_cell(value):
+        if is_missing_cell(value):
             continue
         if isinstance(value, str):
             raise ValueError(
@@ -84,7 +84,7 @@ class CalibrationDataset:
 
     Peptide columns must already be tokenised. ``__post_init__`` validates structure and
     derives ``valid_prediction`` / ``valid_sequence``; it does not parse ProForma strings
-    or compute ``correct`` / ``num_matches``.
+    or compute/validate ``correct`` / ``num_matches``.
 
     Attributes:
         metadata (pd.DataFrame): DataFrame containing metadata and predictions.

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -228,22 +228,7 @@ class CalibrationDataset:
             path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        output_metadata = self.metadata.copy(deep=True)
-
-        if "sequence" in output_metadata.columns:
-            output_metadata["sequence"] = output_metadata["sequence"].apply(
-                tokens_to_proforma
-            )
-        if "prediction" in output_metadata.columns:
-            output_metadata["prediction"] = output_metadata["prediction"].apply(
-                tokens_to_proforma
-            )
-        if "prediction_untokenised" in output_metadata.columns:
-            output_metadata = output_metadata.drop(columns=["prediction_untokenised"])
-        if "valid_sequence" in output_metadata.columns:
-            output_metadata = output_metadata.drop(columns=["valid_sequence"])
-        if "valid_prediction" in output_metadata.columns:
-            output_metadata = output_metadata.drop(columns=["valid_prediction"])
+        output_metadata = self.format_metadata_for_export()
 
         if path.suffix == ".csv":
             output_metadata.to_csv(path, index=False)
@@ -286,6 +271,33 @@ class CalibrationDataset:
             path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         self.metadata.to_parquet(path)
+
+    def format_metadata_for_export(self) -> pd.DataFrame:
+        """Return a copy of metadata formatted for CSV or parquet export.
+
+        Converts ``sequence`` and ``prediction`` token lists to ProForma strings and
+        drops internal columns (``prediction_untokenised``, ``valid_sequence``,
+        ``valid_prediction``). Does not modify the dataset in place.
+
+        Returns:
+            pd.DataFrame: Export-ready metadata copy.
+        """
+        output_metadata = self.metadata.copy(deep=True)
+        if "sequence" in output_metadata.columns:
+            output_metadata["sequence"] = output_metadata["sequence"].apply(
+                tokens_to_proforma
+            )
+        if "prediction" in output_metadata.columns:
+            output_metadata["prediction"] = output_metadata["prediction"].apply(
+                tokens_to_proforma
+            )
+        if "prediction_untokenised" in output_metadata.columns:
+            output_metadata = output_metadata.drop(columns=["prediction_untokenised"])
+        if "valid_sequence" in output_metadata.columns:
+            output_metadata = output_metadata.drop(columns=["valid_sequence"])
+        if "valid_prediction" in output_metadata.columns:
+            output_metadata = output_metadata.drop(columns=["valid_prediction"])
+        return output_metadata
 
     def _create_predicate_error_message(
         self, error: Exception, beam: Optional[List[ScoredSequence]], idx: int

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -11,12 +11,67 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, List, Optional, Tuple, Union
 import pickle
+import warnings
 
 import numpy as np
 import pandas as pd
 
 from winnow.compat.instanovo import ScoredSequence
-from winnow.utils.peptide import tokens_to_proforma
+from winnow.utils.peptide import (
+    _is_missing_cell,
+    as_token_list,
+    is_usable_peptide_label,
+    is_valid_peptide_tokens,
+    tokens_to_proforma,
+)
+
+_LOADER_GUIDANCE = (
+    "Use a DatasetLoader to tokenise raw ProForma strings "
+    "(e.g. InstaNovoDatasetLoader) instead of constructing "
+    "CalibrationDataset directly."
+)
+
+
+def _normalise_and_validate_peptide_column(
+    metadata: pd.DataFrame,
+    column: str,
+) -> None:
+    """Normalise empty containers to None and reject unsupported peptide cells."""
+    for index, value in metadata[column].items():
+        if _is_missing_cell(value):
+            continue
+        if isinstance(value, str):
+            raise ValueError(
+                f"Peptide column {column!r} contains raw strings; "
+                f"expected token lists such as ['P', 'E', 'P']. {_LOADER_GUIDANCE}"
+            )
+        if as_token_list(value) is None:
+            if not is_usable_peptide_label(value):
+                metadata.at[index, column] = None
+                continue
+            raise ValueError(
+                f"Peptide column {column!r} contains an unsupported value of type "
+                f"{type(value).__name__!r}; expected a token list or None. "
+                f"{_LOADER_GUIDANCE}"
+            )
+
+
+def _derive_validity_column(
+    metadata: pd.DataFrame,
+    peptide_column: str,
+    validity_column: str,
+) -> None:
+    """Derive a structural validity flag, warning if a stale column is overwritten."""
+    derived = metadata[peptide_column].apply(is_valid_peptide_tokens)
+    if validity_column in metadata.columns:
+        existing = metadata[validity_column].fillna(False).astype(bool)
+        if not existing.equals(derived.astype(bool)):
+            warnings.warn(
+                f"Existing {validity_column!r} differs from token-structure "
+                "validation and will be overwritten.",
+                stacklevel=2,
+            )
+    metadata[validity_column] = derived
 
 
 @dataclass
@@ -26,6 +81,10 @@ class CalibrationDataset:
     It holds metadata and prediction results and provides various utility methods for filtering,
     saving, and evaluating data. For loading datasets from various file formats, see the
     concrete implementations of the DatasetLoader interface in the data_loaders package.
+
+    Peptide columns must already be tokenised. ``__post_init__`` validates structure and
+    derives ``valid_prediction`` / ``valid_sequence``; it does not parse ProForma strings
+    or compute ``correct`` / ``num_matches``.
 
     Attributes:
         metadata (pd.DataFrame): DataFrame containing metadata and predictions.
@@ -37,11 +96,25 @@ class CalibrationDataset:
     predictions: Optional[List[Optional[List[ScoredSequence]]]] = None
 
     def __post_init__(self):
-        """Validate that metadata and predictions have matching lengths."""
+        """Validate alignment and peptide column structure; derive ``valid_*`` flags."""
         # Allow predictions to be None (no beam predictions available)
         # But if predictions are provided, they must match metadata length
         if self.predictions is not None and len(self.metadata) != len(self.predictions):
             raise AssertionError("Length of metadata and predictions must match")
+
+        if "prediction" not in self.metadata.columns:
+            raise ValueError(
+                "CalibrationDataset requires a 'prediction' column containing "
+                "tokenised peptide predictions. If your inputs are raw peptide "
+                "strings, load them with a DatasetLoader first."
+            )
+
+        _normalise_and_validate_peptide_column(self.metadata, "prediction")
+        _derive_validity_column(self.metadata, "prediction", "valid_prediction")
+
+        if "sequence" in self.metadata.columns:
+            _normalise_and_validate_peptide_column(self.metadata, "sequence")
+            _derive_validity_column(self.metadata, "sequence", "valid_sequence")
 
     def save(self, data_dir: Path) -> None:
         """Save a `CalibrationDataset` to a directory.

--- a/winnow/datasets/calibration_dataset.py
+++ b/winnow/datasets/calibration_dataset.py
@@ -100,7 +100,7 @@ class CalibrationDataset:
         # Allow predictions to be None (no beam predictions available)
         # But if predictions are provided, they must match metadata length
         if self.predictions is not None and len(self.metadata) != len(self.predictions):
-            raise AssertionError("Length of metadata and predictions must match")
+            raise ValueError("Length of metadata and predictions must match")
 
         if "prediction" not in self.metadata.columns:
             raise ValueError(

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -11,7 +11,7 @@ import pandas as pd
 from instanovo.utils.metrics import Metrics
 
 from winnow.utils.peptide import (
-    _is_missing_cell,
+    is_missing_cell,
     as_token_list,
     is_usable_peptide_label,
     is_valid_peptide_tokens,
@@ -159,7 +159,7 @@ def normalize_peptide_cell(
     """
     if require_label and not is_usable_peptide_label(value):
         return None
-    if _is_missing_cell(value):
+    if is_missing_cell(value):
         return None
     if isinstance(value, str):
         if value.strip() == "":

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -10,6 +10,13 @@ import polars as pl
 import pandas as pd
 from instanovo.utils.metrics import Metrics
 
+from winnow.utils.peptide import (
+    _is_missing_cell,
+    as_token_list,
+    is_usable_peptide_label,
+    is_valid_peptide_tokens,
+)
+
 if TYPE_CHECKING:
     from matchms import Spectrum
 
@@ -114,63 +121,6 @@ def add_index_cols(df: pl.DataFrame, fp: Path | str) -> pl.DataFrame:
 
 
 _add_index_cols_fn = add_index_cols
-
-
-def _is_missing_cell(value: object) -> bool:
-    """Return True when a peptide cell is absent (None, NaN, pd.NA)."""
-    if value is None:
-        return True
-    if isinstance(value, float) and value != value:
-        return True
-    try:
-        if pd.isna(value):
-            return True
-    except (TypeError, ValueError):
-        pass
-    return False
-
-
-def is_usable_peptide_label(value: object) -> bool:
-    """Return True when a raw peptide cell contains a label or sequence string."""
-    if _is_missing_cell(value):
-        return False
-    if isinstance(value, str):
-        return value.strip() != ""
-    if isinstance(value, (list, tuple)):
-        return len(value) > 0
-    if isinstance(value, pl.Series):
-        return len(value) > 0
-    if isinstance(value, np.ndarray):
-        return value.size > 0
-    if hasattr(value, "tolist"):
-        tokens = value.tolist()
-        return isinstance(tokens, (list, tuple)) and len(tokens) > 0
-    return True
-
-
-def as_token_list(value: object) -> list[str] | None:
-    """Coerce a metadata cell to a non-empty AA token list, or ``None``.
-
-    Accepts container types that already hold token strings. Does not parse raw
-    peptide strings; use :func:`normalize_peptide_cell` for that.
-    """
-    if _is_missing_cell(value):
-        return None
-    if isinstance(value, pl.Series):
-        tokens = value.to_list()
-        return list(tokens) if tokens else None
-    if isinstance(value, (list, tuple)):
-        tokens = list(value)
-        return tokens if tokens else None
-    if isinstance(value, np.ndarray):
-        tokens = value.tolist()
-        return tokens if isinstance(tokens, list) and tokens else None
-    return None
-
-
-def is_valid_peptide_tokens(value: object) -> bool:
-    """Return True when a cell holds a non-empty token list (not a raw string)."""
-    return as_token_list(value) is not None
 
 
 def _normalize_leucine_tokens(tokens: list[str]) -> list[str]:
@@ -469,21 +419,21 @@ def finalize_peptide_metadata(
     )
 
 
-def _ensure_valid_sequence_column(metadata: pd.DataFrame) -> None:
-    """Set ``valid_sequence`` from ``sequence`` when the column is absent."""
-    if "sequence" in metadata.columns and "valid_sequence" not in metadata.columns:
-        metadata["valid_sequence"] = metadata["sequence"].apply(is_valid_peptide_tokens)
-
-
 def labelled_training_mask(metadata: pd.DataFrame) -> np.ndarray:
     """Return a boolean mask of rows eligible for supervised training or FDR fit.
 
-    When a ``sequence`` column is present, ``valid_sequence`` is derived from it
-    if not already supplied. When neither column exists (e.g. precomputed labels
-    only), all rows are included.
+    When a ``sequence`` column is present, ``valid_sequence`` must already be
+    finalised (e.g. by ``CalibrationDataset.__post_init__`` or a DatasetLoader).
+    When neither column exists (e.g. precomputed labels only), all rows are
+    included.
     """
     if "sequence" in metadata.columns:
-        _ensure_valid_sequence_column(metadata)
+        if "valid_sequence" not in metadata.columns:
+            raise ValueError(
+                "Metadata with a 'sequence' column requires a finalised "
+                "'valid_sequence' column. Load data through a DatasetLoader or "
+                "construct a CalibrationDataset instead of passing raw metadata."
+            )
         return metadata["valid_sequence"].fillna(False).to_numpy(dtype=bool)
     return np.ones(len(metadata), dtype=bool)
 

--- a/winnow/datasets/data_loaders/winnow.py
+++ b/winnow/datasets/data_loaders/winnow.py
@@ -58,13 +58,8 @@ class WinnowDatasetLoader(DatasetLoader):
                 f"The file should be a valid CSV containing PSM metadata. Error: {e}"
             ) from e
 
-        if "sequence" in metadata.columns:
-            metadata["sequence"] = metadata["sequence"].apply(
-                self.metrics._split_peptide
-            )
-        metadata["prediction"] = metadata["prediction"].apply(
-            self.metrics._split_peptide
-        )
+        # Reload-specific array parsing for saved CSV serialisations. Preserve both
+        # comma-delimited lists and numpy print formats.
         metadata["mz_array"] = metadata["mz_array"].apply(
             lambda s: (
                 ast.literal_eval(s)
@@ -84,14 +79,18 @@ class WinnowDatasetLoader(DatasetLoader):
             )
         )
 
-        if "valid_prediction" not in metadata.columns:
-            metadata["valid_prediction"] = metadata["prediction"].apply(
-                utils.is_valid_peptide_tokens
-            )
-        if "sequence" in metadata.columns and "valid_sequence" not in metadata.columns:
-            metadata["valid_sequence"] = metadata["sequence"].apply(
-                utils.is_valid_peptide_tokens
-            )
+        has_labels = "sequence" in metadata.columns and any(
+            utils.is_usable_peptide_label(value) for value in metadata["sequence"]
+        )
+        if "sequence" in metadata.columns and not has_labels:
+            metadata = metadata.drop(columns=["sequence"])
+
+        metadata = utils.finalize_peptide_metadata(
+            metadata,
+            self.metrics,
+            has_labels=has_labels,
+            residue_remapping=self.metrics.residue_set.residue_remapping,
+        )
 
         predictions_pkl_path = data_path / Path("predictions.pkl")
         if predictions_pkl_path.exists():

--- a/winnow/fdr/base.py
+++ b/winnow/fdr/base.py
@@ -2,7 +2,7 @@
 
 from abc import ABCMeta
 from abc import abstractmethod
-from typing import Iterable, Tuple, TypeVar
+from typing import Generic, Tuple, TypeVar
 import warnings
 
 import numpy as np
@@ -12,10 +12,10 @@ from numpy.typing import NDArray
 
 from winnow.datasets.psm_dataset import PSMDataset
 
-T = TypeVar("T", bound=Iterable)
+T = TypeVar("T")
 
 
-class FDRControl(metaclass=ABCMeta):
+class FDRControl(Generic[T], metaclass=ABCMeta):
     """The interface for FDR control classes."""
 
     def __init__(self) -> None:

--- a/winnow/fdr/database_grounded.py
+++ b/winnow/fdr/database_grounded.py
@@ -34,7 +34,8 @@ class DatabaseGroundedFDRControl(FDRControl[CalibrationDataset]):
         Raises:
             ValueError: If required finalised label columns are missing.
         """
-        assert len(dataset) > 0, "Fit method requires non-empty data"
+        if len(dataset) == 0:
+            raise ValueError("Fit method requires non-empty data")
 
         metadata = dataset.metadata
         missing = [

--- a/winnow/fdr/database_grounded.py
+++ b/winnow/fdr/database_grounded.py
@@ -1,66 +1,59 @@
-from typing import Tuple
-
 import numpy as np
-import pandas as pd
-from instanovo.utils.metrics import Metrics
-from instanovo.utils.residues import ResidueSet
 
-from winnow.datasets.data_loaders.utils import (
-    finalize_peptide_metadata,
-    require_labelled_rows,
-)
+from winnow.datasets.calibration_dataset import CalibrationDataset
+from winnow.datasets.data_loaders.utils import require_labelled_rows
 from winnow.fdr.base import FDRControl
 
 
-class DatabaseGroundedFDRControl(FDRControl):
+class DatabaseGroundedFDRControl(FDRControl[CalibrationDataset]):
     """Performs false discovery rate (FDR) control by grounding predictions against a reference database.
 
     This method estimates FDR thresholds by comparing model-predicted peptides to ground-truth peptides from a database.
+    It expects finalised labelled metadata from a DatasetLoader, including ``correct`` and ``valid_sequence``.
     """
 
     def __init__(
         self,
         confidence_feature: str,
-        residue_masses: dict[str, float],
-        isotope_error_range: Tuple[int, int] = (0, 1),
         drop: int = 10,
     ) -> None:
         super().__init__()
         self.confidence_feature = confidence_feature
-        self.residue_masses = residue_masses
-        self.isotope_error_range = isotope_error_range
         self.drop = drop
 
-        self.metrics = Metrics(
-            residue_set=ResidueSet(residue_masses=residue_masses),
-            isotope_error_range=isotope_error_range,
-        )
+    def fit(self, dataset: CalibrationDataset) -> None:
+        """Computes the precision-recall curve from finalised correctness labels.
 
-    def fit(  # type: ignore
-        self,
-        dataset: pd.DataFrame,
-    ) -> None:
-        """Computes the precision-recall curve by comparing model predictions to database-grounded peptide sequences.
-
-        Per-row correctness is derived from ``sequence`` vs ``prediction``. Rows with
-        ``valid_sequence=False`` receive ``correct=False`` but are excluded from the
-        FDR curve.
+        Rows with ``valid_sequence=False`` are excluded from the FDR curve. Per-row
+        correctness must already be present in ``correct``.
 
         Args:
-            dataset: DataFrame with ``sequence``, ``prediction``, and the confidence
-                column named by ``confidence_feature``.
+            dataset: Finalised calibration dataset with ``correct``, ``valid_sequence``,
+                and the confidence column named by ``confidence_feature``.
+
+        Raises:
+            ValueError: If required finalised label columns are missing.
         """
         assert len(dataset) > 0, "Fit method requires non-empty data"
 
-        finalize_peptide_metadata(
-            dataset,
-            self.metrics,
-            has_labels=True,
-        )
-        self.preds = dataset[["correct", self.confidence_feature]]
+        metadata = dataset.metadata
+        missing = [
+            column
+            for column in ("correct", "valid_sequence", self.confidence_feature)
+            if column not in metadata.columns
+        ]
+        if missing:
+            raise ValueError(
+                "This operation requires finalised labelled metadata with "
+                f"{', '.join(repr(c) for c in missing)}. "
+                "Load labelled data through a DatasetLoader before fitting/running "
+                "diagnostics."
+            )
 
-        mask = require_labelled_rows(dataset, context="Database-grounded FDR fit")
-        labelled = dataset.loc[mask].sort_values(
+        self.preds = metadata[["correct", self.confidence_feature]]
+
+        mask = require_labelled_rows(metadata, context="Database-grounded FDR fit")
+        labelled = metadata.loc[mask].sort_values(
             by=self.confidence_feature, ascending=False
         )
 

--- a/winnow/fdr/nonparametric.py
+++ b/winnow/fdr/nonparametric.py
@@ -5,7 +5,7 @@ from numpy.typing import NDArray
 from winnow.fdr.base import FDRControl
 
 
-class NonParametricFDRControl(FDRControl):
+class NonParametricFDRControl(FDRControl[pd.Series]):
     """A non-parametric false discovery rate (FDR) control method that estimates FDR directly from confidence scores.
 
     This implementation uses a non-parametric approach to estimate FDR by computing the cumulative error probabilities across sorted confidence scores.
@@ -19,19 +19,19 @@ class NonParametricFDRControl(FDRControl):
         self._is_correct: NDArray[np.bool_] | None = None
         self._null_scores: NDArray[np.float64] | None = None
 
-    def fit(self, dataset: pd.DataFrame) -> None:
-        """Fit the FDR control method to a dataset of confidence scores.
+    def fit(self, dataset: pd.Series) -> None:
+        """Fit the FDR control method to a series of confidence scores.
 
         Args:
-            dataset (pd.DataFrame):
-                An array of confidence scores from the dataset.
+            dataset: One-dimensional series of confidence scores (for example
+                ``metadata["calibrated_confidence"]``).
         """
         assert len(dataset) > 0, "Fit method requires non-empty data"
-        dataset = dataset.to_numpy()
+        scores = dataset.to_numpy()
 
         # Store sorted confidence scores and their indices
-        self._sorted_indices = np.argsort(-dataset)  # Sort in descending order
-        self._confidence_scores = dataset[self._sorted_indices]
+        self._sorted_indices = np.argsort(-scores)  # Sort in descending order
+        self._confidence_scores = scores[self._sorted_indices]
 
         # Compute error probabilities (1 - confidence)
         error_probabilities = 1 - self._confidence_scores

--- a/winnow/fdr/nonparametric.py
+++ b/winnow/fdr/nonparametric.py
@@ -26,7 +26,9 @@ class NonParametricFDRControl(FDRControl[pd.Series]):
             dataset: One-dimensional series of confidence scores (for example
                 ``metadata["calibrated_confidence"]``).
         """
-        assert len(dataset) > 0, "Fit method requires non-empty data"
+        if len(dataset) == 0:
+            raise ValueError("Fit method requires non-empty data")
+
         scores = dataset.to_numpy()
 
         # Store sorted confidence scores and their indices

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -524,13 +524,12 @@ def diagnose_calibration_entry_point(
     )
 
     confidence_col = cfg.fdr_control.confidence_column
-    diagnostic_data = DiagnosticArrays.from_raw(
-        dataset.metadata.loc[labels.index, confidence_col],
-        labels,
-    )
+    # Use the same labelled population for FDR cutoff estimation and diagnostics.
+    labelled_scores = dataset.metadata.loc[labels.index, confidence_col]
+    diagnostic_data = DiagnosticArrays.from_raw(labelled_scores, labels)
 
     fdr_control = NonParametricFDRControl()
-    fdr_control.fit(dataset.metadata[confidence_col])
+    fdr_control.fit(labelled_scores)
     conf_cutoff = fdr_control.get_confidence_cutoff(
         threshold=cfg.fdr_control.fdr_threshold
     )

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -90,7 +90,7 @@ def apply_fdr_control(
         fdr_control.fit(dataset=dataset.metadata[confidence_column])
         dataset.metadata = fdr_control.add_psm_pep(dataset.metadata, confidence_column)
     else:
-        fdr_control.fit(dataset=dataset.metadata[confidence_column])
+        fdr_control.fit(dataset=dataset)
 
     dataset.metadata = fdr_control.add_psm_fdr(dataset.metadata, confidence_column)
     dataset.metadata = fdr_control.add_psm_q_value(dataset.metadata, confidence_column)
@@ -423,7 +423,6 @@ def diagnose_calibration_entry_point(
     """Run tail calibration diagnostics on a labelled holdout set."""
     from hydra import initialize_config_dir, compose
     from hydra.utils import instantiate
-    from omegaconf import OmegaConf
 
     from winnow.calibration.calibrator import ProbabilityCalibrator
     from winnow.calibration.diagnostics import (
@@ -469,14 +468,6 @@ def diagnose_calibration_entry_point(
     dataset = filter_dataset(dataset)
     logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
-    residue_masses = OmegaConf.to_container(cfg.residue_masses, resolve=True)
-    residue_remapping_cfg = getattr(cfg.data_loader, "residue_remapping", None)
-    residue_remapping = (
-        {}
-        if residue_remapping_cfg is None
-        else OmegaConf.to_container(residue_remapping_cfg, resolve=True)
-    )
-
     logger.info("Loading trained calibrator.")
     calibrator = ProbabilityCalibrator.load(
         pretrained_model_name_or_path=cfg.calibrator.pretrained_model_name_or_path,
@@ -490,8 +481,6 @@ def diagnose_calibration_entry_point(
         dataset,
         diagnostics.label_source,
         label_column,
-        residue_masses=residue_masses,
-        residue_remapping=residue_remapping,
     )
     logger.info(
         f"Resolved labels via label_source={diagnostics.label_source!r} "

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -57,7 +57,7 @@ def print_config(cfg) -> None:
     formatter.print_config(cfg)
 
 
-def filter_dataset(dataset: CalibrationDataset) -> CalibrationDataset:
+def _filter_dataset(dataset: CalibrationDataset) -> CalibrationDataset:
     """Filter out rows whose predictions are empty or contain unsupported PSMs.
 
     Args:
@@ -78,7 +78,7 @@ def filter_dataset(dataset: CalibrationDataset) -> CalibrationDataset:
     )
 
 
-def apply_fdr_control(
+def _apply_fdr_control(
     fdr_control: Union[NonParametricFDRControl, DatabaseGroundedFDRControl],
     dataset: CalibrationDataset,
     fdr_threshold: float,
@@ -114,7 +114,7 @@ def apply_fdr_control(
     )
 
 
-def separate_metadata_and_predictions(
+def _separate_metadata_and_predictions(
     dataset_metadata: pd.DataFrame,
     confidence_column: str,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
@@ -149,7 +149,7 @@ def separate_metadata_and_predictions(
     return dataset_metadata, dataset_preds_and_fdr_metrics
 
 
-def save_predict_outputs(
+def _save_predict_outputs(
     dataset: CalibrationDataset,
     output_folder: Union[Path, str],
     confidence_column: str,
@@ -165,18 +165,26 @@ def save_predict_outputs(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     formatted_metadata = dataset.format_metadata_for_export()
-    metadata, preds_and_fdr_metrics = separate_metadata_and_predictions(
+    metadata, preds_and_fdr_metrics = _separate_metadata_and_predictions(
         formatted_metadata, confidence_column
     )
     metadata.to_csv(output_dir / "metadata.csv", index=False)
     preds_and_fdr_metrics.to_csv(output_dir / "preds_and_fdr_metrics.csv", index=False)
 
 
-def check_if_labelled(dataset: CalibrationDataset) -> None:
-    """Check if the dataset contains a ground-truth column."""
-    if "sequence" not in dataset.metadata.columns:
+def _check_if_labelled(dataset: CalibrationDataset) -> None:
+    """Check that metadata has finalised labels for database-grounded FDR."""
+    missing = [
+        column
+        for column in ("correct", "valid_sequence")
+        if column not in dataset.metadata.columns
+    ]
+    if missing:
         raise ValueError(
-            "Database-grounded FDR control can only be performed on annotated data."
+            "This operation requires finalised labelled metadata with "
+            f"{', '.join(repr(c) for c in missing)}. "
+            "Load labelled data through a DatasetLoader before fitting/running "
+            "diagnostics."
         )
 
 
@@ -232,7 +240,7 @@ def train_entry_point(
     logger.info(f"Loaded: {len(annotated_dataset.metadata)} spectra")
 
     logger.info("Filtering dataset for empty predictions.")
-    annotated_dataset = filter_dataset(annotated_dataset)
+    annotated_dataset = _filter_dataset(annotated_dataset)
 
     logger.info(f"After filtering: {len(annotated_dataset.metadata)} spectra")
 
@@ -320,7 +328,7 @@ def compute_features_entry_point(
 
     if cfg.filter_empty_predictions:
         logger.info("Filtering dataset for empty predictions.")
-        dataset = filter_dataset(dataset)
+        dataset = _filter_dataset(dataset)
         logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
     logger.info("Instantiating calibrator from config.")
@@ -389,7 +397,7 @@ def predict_entry_point(
     logger.info(f"Loaded: {len(dataset.metadata)} spectra")
 
     logger.info("Filtering dataset for empty predictions.")
-    dataset = filter_dataset(dataset)
+    dataset = _filter_dataset(dataset)
 
     logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
@@ -420,11 +428,11 @@ def predict_entry_point(
 
     # Check if dataset is labelled for database-grounded FDR
     if isinstance(fdr_control, DatabaseGroundedFDRControl):
-        check_if_labelled(dataset)
+        _check_if_labelled(dataset)
 
     # Apply FDR control
     logger.info(f"Applying {fdr_control.__class__.__name__} FDR control.")
-    filtered_dataset = apply_fdr_control(
+    filtered_dataset = _apply_fdr_control(
         fdr_control,
         dataset,
         cfg.fdr_control.fdr_threshold,
@@ -434,7 +442,7 @@ def predict_entry_point(
     # Write output
     logger.info(f"Final dataset: {len(filtered_dataset)} spectra")
     logger.info(f"Writing output to {cfg.output_folder}")
-    save_predict_outputs(
+    _save_predict_outputs(
         filtered_dataset,
         cfg.output_folder,
         cfg.fdr_control.confidence_column,
@@ -493,7 +501,7 @@ def diagnose_calibration_entry_point(
     dataset = data_loader.load(**dataset_params)
     logger.info(f"Loaded: {len(dataset.metadata)} spectra")
 
-    dataset = filter_dataset(dataset)
+    dataset = _filter_dataset(dataset)
     logger.info(f"After filtering: {len(dataset.metadata)} spectra")
 
     logger.info("Loading trained calibrator.")

--- a/winnow/scripts/main.py
+++ b/winnow/scripts/main.py
@@ -7,6 +7,7 @@ needed, significantly reducing --help and config command times.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Union, Tuple, Optional, List, TYPE_CHECKING, Annotated
 import typer
 import logging
@@ -82,22 +83,93 @@ def apply_fdr_control(
     dataset: CalibrationDataset,
     fdr_threshold: float,
     confidence_column: str,
-) -> pd.DataFrame:
-    """Apply FDR control to a dataset."""
+) -> CalibrationDataset:
+    """Apply FDR control and return a filtered dataset without mutating the input.
+
+    Fits the FDR method, annotates a copy of the metadata with FDR columns, then
+    returns a new ``CalibrationDataset`` containing only PSMs at or above the
+    confidence cutoff for ``fdr_threshold``.
+    """
+    from winnow.datasets.calibration_dataset import CalibrationDataset
     from winnow.fdr.nonparametric import NonParametricFDRControl
 
     if isinstance(fdr_control, NonParametricFDRControl):
         fdr_control.fit(dataset=dataset.metadata[confidence_column])
-        dataset.metadata = fdr_control.add_psm_pep(dataset.metadata, confidence_column)
+        metadata = fdr_control.add_psm_pep(dataset.metadata, confidence_column)
     else:
         fdr_control.fit(dataset=dataset)
+        metadata = dataset.metadata
 
-    dataset.metadata = fdr_control.add_psm_fdr(dataset.metadata, confidence_column)
-    dataset.metadata = fdr_control.add_psm_q_value(dataset.metadata, confidence_column)
+    metadata = fdr_control.add_psm_fdr(metadata, confidence_column)
+    metadata = fdr_control.add_psm_q_value(metadata, confidence_column)
     confidence_cutoff = fdr_control.get_confidence_cutoff(threshold=fdr_threshold)
-    output_data = dataset.metadata
-    output_data = output_data[output_data[confidence_column] >= confidence_cutoff]
-    return output_data
+
+    annotated_dataset = CalibrationDataset(
+        metadata=metadata,
+        predictions=dataset.predictions,
+    )
+    # Only retain PSMs with confidence scores equal to or greater than the cutoff
+    return annotated_dataset.filter_entries(
+        metadata_predicate=lambda row: row[confidence_column] < confidence_cutoff
+    )
+
+
+def separate_metadata_and_predictions(
+    dataset_metadata: pd.DataFrame,
+    confidence_column: str,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Separate metadata from prediction and FDR metric columns.
+
+    Args:
+        dataset_metadata: Formatted metadata dataframe to split.
+        confidence_column: Name of the confidence column used for FDR control.
+
+    Returns:
+        Tuple of (metadata without prediction/FDR columns, predictions and FDR metrics).
+    """
+    preds_and_fdr_metrics_cols = [
+        "prediction",
+        confidence_column,
+        "psm_fdr",
+        "psm_q_value",
+    ]
+    if "psm_pep" in dataset_metadata.columns:
+        preds_and_fdr_metrics_cols.append("psm_pep")
+    if "sequence" in dataset_metadata.columns:
+        preds_and_fdr_metrics_cols.append("sequence")
+        if "num_matches" in dataset_metadata.columns:
+            preds_and_fdr_metrics_cols.append("num_matches")
+        if "correct" in dataset_metadata.columns:
+            preds_and_fdr_metrics_cols.append("correct")
+
+    dataset_preds_and_fdr_metrics = dataset_metadata[
+        ["spectrum_id"] + preds_and_fdr_metrics_cols
+    ]
+    dataset_metadata = dataset_metadata.drop(columns=preds_and_fdr_metrics_cols)
+    return dataset_metadata, dataset_preds_and_fdr_metrics
+
+
+def save_predict_outputs(
+    dataset: CalibrationDataset,
+    output_folder: Union[Path, str],
+    confidence_column: str,
+) -> None:
+    """Write predict outputs as separate metadata and prediction/FDR CSV files.
+
+    Args:
+        dataset: Filtered dataset after FDR control.
+        output_folder: Directory for ``metadata.csv`` and ``preds_and_fdr_metrics.csv``.
+        confidence_column: Confidence column to include in the predictions file.
+    """
+    output_dir = Path(output_folder)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    formatted_metadata = dataset.format_metadata_for_export()
+    metadata, preds_and_fdr_metrics = separate_metadata_and_predictions(
+        formatted_metadata, confidence_column
+    )
+    metadata.to_csv(output_dir / "metadata.csv", index=False)
+    preds_and_fdr_metrics.to_csv(output_dir / "preds_and_fdr_metrics.csv", index=False)
 
 
 def check_if_labelled(dataset: CalibrationDataset) -> None:
@@ -106,44 +178,6 @@ def check_if_labelled(dataset: CalibrationDataset) -> None:
         raise ValueError(
             "Database-grounded FDR control can only be performed on annotated data."
         )
-
-
-def separate_metadata_and_predictions(
-    dataset_metadata: pd.DataFrame,
-    fdr_control: Union[NonParametricFDRControl, DatabaseGroundedFDRControl],
-    confidence_column: str,
-) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """Separate out metadata from prediction and FDR metrics.
-
-    Args:
-        dataset_metadata: The metadata dataframe to separate out prediction and FDR metrics from metadata and computed features.
-        fdr_control: The FDR control object used (to determine which columns were added).
-        confidence_column: The name of the confidence column.
-
-    Returns:
-        Tuple[pd.DataFrame, pd.DataFrame]: A tuple containing the metadata dataframe and the prediction and FDR metrics dataframe.
-    """
-    from winnow.fdr.nonparametric import NonParametricFDRControl
-
-    # Separate out metadata from prediction and FDR metrics
-    preds_and_fdr_metrics_cols = [
-        "prediction",
-        confidence_column,
-        "psm_fdr",
-        "psm_q_value",
-    ]
-    # NonParametricFDRControl adds psm_pep column
-    if isinstance(fdr_control, NonParametricFDRControl):
-        preds_and_fdr_metrics_cols.append("psm_pep")
-    if "sequence" in dataset_metadata.columns:
-        preds_and_fdr_metrics_cols.append("sequence")
-        preds_and_fdr_metrics_cols.append("num_matches")
-        preds_and_fdr_metrics_cols.append("correct")
-    dataset_preds_and_fdr_metrics = dataset_metadata[
-        ["spectrum_id"] + preds_and_fdr_metrics_cols
-    ]
-    dataset_metadata = dataset_metadata.drop(columns=preds_and_fdr_metrics_cols)
-    return dataset_metadata, dataset_preds_and_fdr_metrics
 
 
 def train_entry_point(
@@ -335,7 +369,6 @@ def predict_entry_point(
         return
 
     from winnow.calibration.calibrator import ProbabilityCalibrator
-    from winnow.datasets.calibration_dataset import CalibrationDataset
     from winnow.fdr.database_grounded import DatabaseGroundedFDRControl
 
     logger.info("Starting prediction pipeline.")
@@ -391,7 +424,7 @@ def predict_entry_point(
 
     # Apply FDR control
     logger.info(f"Applying {fdr_control.__class__.__name__} FDR control.")
-    dataset_metadata = apply_fdr_control(
+    filtered_dataset = apply_fdr_control(
         fdr_control,
         dataset,
         cfg.fdr_control.fdr_threshold,
@@ -399,17 +432,12 @@ def predict_entry_point(
     )
 
     # Write output
-    logger.info(f"Final dataset: {len(dataset_metadata)} spectra")
+    logger.info(f"Final dataset: {len(filtered_dataset)} spectra")
     logger.info(f"Writing output to {cfg.output_folder}")
-    dataset_metadata, dataset_preds_and_fdr_metrics = separate_metadata_and_predictions(
-        dataset_metadata, fdr_control, cfg.fdr_control.confidence_column
-    )
-
-    CalibrationDataset(metadata=dataset_metadata).save_metadata(
-        cfg.output_folder + "/" + "metadata.csv"
-    )
-    CalibrationDataset(metadata=dataset_preds_and_fdr_metrics).save_metadata(
-        cfg.output_folder + "/" + "preds_and_fdr_metrics.csv"
+    save_predict_outputs(
+        filtered_dataset,
+        cfg.output_folder,
+        cfg.fdr_control.confidence_column,
     )
 
     logger.info("Prediction pipeline completed successfully.")

--- a/winnow/utils/peptide.py
+++ b/winnow/utils/peptide.py
@@ -7,7 +7,7 @@ import pandas as pd
 import polars as pl
 
 
-def _is_missing_cell(value: object) -> bool:
+def is_missing_cell(value: object) -> bool:
     """Return True when a peptide cell is absent (None, NaN, pd.NA)."""
     if value is None:
         return True
@@ -23,7 +23,7 @@ def _is_missing_cell(value: object) -> bool:
 
 def is_usable_peptide_label(value: object) -> bool:
     """Return True when a raw peptide cell contains a label or sequence string."""
-    if _is_missing_cell(value):
+    if is_missing_cell(value):
         return False
     if isinstance(value, str):
         return value.strip() != ""
@@ -46,7 +46,7 @@ def as_token_list(value: object) -> list[str] | None:
     peptide strings; use
     :func:`winnow.datasets.data_loaders.utils.normalize_peptide_cell` for that.
     """
-    if _is_missing_cell(value):
+    if is_missing_cell(value):
         return None
     if isinstance(value, pl.Series):
         tokens = value.to_list()

--- a/winnow/utils/peptide.py
+++ b/winnow/utils/peptide.py
@@ -2,6 +2,68 @@
 
 from __future__ import annotations
 
+import numpy as np
+import pandas as pd
+import polars as pl
+
+
+def _is_missing_cell(value: object) -> bool:
+    """Return True when a peptide cell is absent (None, NaN, pd.NA)."""
+    if value is None:
+        return True
+    if isinstance(value, float) and value != value:
+        return True
+    try:
+        if pd.isna(value):
+            return True
+    except (TypeError, ValueError):
+        pass
+    return False
+
+
+def is_usable_peptide_label(value: object) -> bool:
+    """Return True when a raw peptide cell contains a label or sequence string."""
+    if _is_missing_cell(value):
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (list, tuple)):
+        return len(value) > 0
+    if isinstance(value, pl.Series):
+        return len(value) > 0
+    if isinstance(value, np.ndarray):
+        return value.size > 0
+    if hasattr(value, "tolist"):
+        tokens = value.tolist()
+        return isinstance(tokens, (list, tuple)) and len(tokens) > 0
+    return True
+
+
+def as_token_list(value: object) -> list[str] | None:
+    """Coerce a metadata cell to a non-empty AA token list, or ``None``.
+
+    Accepts container types that already hold token strings. Does not parse raw
+    peptide strings; use
+    :func:`winnow.datasets.data_loaders.utils.normalize_peptide_cell` for that.
+    """
+    if _is_missing_cell(value):
+        return None
+    if isinstance(value, pl.Series):
+        tokens = value.to_list()
+        return list(tokens) if tokens else None
+    if isinstance(value, (list, tuple)):
+        tokens = list(value)
+        return tokens if tokens else None
+    if isinstance(value, np.ndarray):
+        tokens = value.tolist()
+        return tokens if isinstance(tokens, list) and tokens else None
+    return None
+
+
+def is_valid_peptide_tokens(value: object) -> bool:
+    """Return True when a cell holds a non-empty token list (not a raw string)."""
+    return as_token_list(value) is not None
+
 
 def _is_standalone_modification(token: str) -> bool:
     """Check if a token is a standalone modification (not attached to an amino acid).


### PR DESCRIPTION
## Summary

Loaders are now the single place that tokenises ProForma strings and finalises labelled columns (`correct`, `valid_sequence`, `num_matches`). `CalibrationDataset` validates peptide structure on construction; calibration, diagnostics and FDR consume that metadata instead of re-deriving labels.

This removes divergent behaviour where `DatabaseGroundedFDRControl`, diagnostics and ad-hoc `DataFrame` construction each tokenised or computed `correct` independently.

## Changes

- **`CalibrationDataset`**: requires tokenised `prediction`; derives `valid_prediction` / `valid_sequence`; rejects raw strings and unsupported cell types.
- **Loaders**: `finalize_peptide_metadata()` is the only path for correctness labels; `labelled_training_mask()` requires pre-finalised `valid_sequence`.
- **Database-grounded FDR**: `fit(CalibrationDataset)`; drops `residue_masses` / `isotope_error_range`; expects `correct` and `valid_sequence` in metadata.
- **Diagnostics**: removes `compute_correct_from_sequence()`; `label_source="sequence"` reads loader-finalised `correct`.
- **Misc**: peptide cell helpers move to `winnow.utils.peptide`; `FDRControl` becomes `Generic[T]`; iRT sequence-key fix; docs updated.

## Breaking changes

| Before | After |
| --- | --- |
| `DatabaseGroundedFDRControl(..., residue_masses=..., isotope_error_range=...)` | `confidence_feature` and `drop` only |
| `fdr_control.fit(dataframe)` | `fdr_control.fit(CalibrationDataset(...))` with `correct` / `valid_sequence` |
| Raw strings in `metadata["prediction"]` | `ValueError`; encouraged to load via `DatasetLoader` |
| Diagnostics derived `correct` at runtime | Requires loader-finalised `correct` / `valid_sequence` |

**Migration:** load labelled data through a `DatasetLoader` (or call `finalize_peptide_metadata()` before constructing `CalibrationDataset`).

