### PR TITLE
Feat: pi-PrimeNovo data loader

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -18,29 +18,60 @@ from winnow.datasets.data_loaders import (
 )
 from pathlib import Path
 
+# ProForma residue → mass (subset; full map in configs/residues.yaml)
+residue_masses = {
+    "G": 57.021464,
+    "A": 71.037114,
+    "S": 87.032028,
+    "P": 97.052764,
+    "V": 99.068414,
+    "T": 101.047670,
+    "C": 103.009185,
+    "M": 131.040485,
+    "C[UNIMOD:4]": 160.030649,
+    "M[UNIMOD:35]": 147.035400,
+    "[UNIMOD:1]": 42.010565,
+    "[UNIMOD:5]": 43.005814,
+}
+
 # Load using InstaNovo data loader
-loader = InstaNovoDatasetLoader()
+loader = InstaNovoDatasetLoader(residue_masses=residue_masses)
 dataset = loader.load(
     data_path=Path("spectrum_data.parquet"),
     predictions_path=Path("predictions.csv")
 )
 
 # Load using MZTab data loader
-mztab_loader = MZTabDatasetLoader()
+mztab_loader = MZTabDatasetLoader(
+    residue_masses=residue_masses,
+    residue_remapping={"M+15.995": "M[UNIMOD:35]"},
+)
 dataset = mztab_loader.load(
     data_path=Path("spectrum_data.parquet"),
     predictions_path=Path("predictions.mztab")
 )
 
 # Load using PrimeNovo data loader (MGF + TSV)
-primenovo_loader = PrimeNovoDatasetLoader()
+primenovo_loader = PrimeNovoDatasetLoader(
+    residue_masses=residue_masses,
+    mid_sequence_n_terminal_mods=[
+        "[+42.011]",
+        "[+43.006]",
+    ],
+    residue_remapping={
+        "M[+15.995]": "M[UNIMOD:35]",
+        "C[+57.021]": "C[UNIMOD:4]",
+        "[+42.011]": "[UNIMOD:1]",
+        "[+43.006]": "[UNIMOD:5]",
+    },
+)
 dataset = primenovo_loader.load(
     data_path=Path("spectrum_data.mgf"),
     predictions_path=Path("primenovo_predictions.tsv")
 )
 
 # Load previously saved dataset
-winnow_loader = WinnowDatasetLoader()
+winnow_loader = WinnowDatasetLoader(residue_masses=residue_masses)
 dataset = winnow_loader.load(data_path=Path("saved_dataset_directory"))
 
 # Save dataset (Winnow's internal format)
@@ -58,7 +89,9 @@ dataset.save(Path("output_directory"))
 
 ### Data loaders
 
-The datasets module provides several data loaders that implement the `DatasetLoader` protocol:
+The datasets module provides several data loaders that implement the `DatasetLoader` protocol.
+
+All loaders require `residue_masses` (ProForma residue → mass; see `configs/residues.yaml`). Loaders that ingest tool-specific peptide notation also take `residue_remapping`.
 
 #### InstaNovoDatasetLoader
 
@@ -67,7 +100,22 @@ Loads InstaNovo predictions from CSV format along with spectrum data from Parque
 ```python
 from winnow.datasets.data_loaders import InstaNovoDatasetLoader
 
-loader = InstaNovoDatasetLoader()
+residue_masses = {
+    "G": 57.021464,
+    "A": 71.037114,
+    "C": 103.009185,
+    "M": 131.040485,
+    "C[UNIMOD:4]": 160.030649,
+    "M[UNIMOD:35]": 147.035400,
+}
+
+loader = InstaNovoDatasetLoader(
+    residue_masses=residue_masses,
+    residue_remapping={
+        "M(ox)": "M[UNIMOD:35]",
+        "C(+57.02)": "C[UNIMOD:4]",
+    },
+)
 dataset = loader.load(
     data_path=Path("spectrum_data.parquet"),  # Spectrum metadata
     predictions_path=Path("instanovo_predictions.csv")  # InstaNovo beam predictions
@@ -81,16 +129,27 @@ Loads predictions from MZTab format, supporting both traditional search engines 
 ```python
 from winnow.datasets.data_loaders import MZTabDatasetLoader
 
-# Default loader (uses Casanovo residue mapping)
-loader = MZTabDatasetLoader()
+residue_masses = {
+    "G": 57.021464,
+    "A": 71.037114,
+    "C": 103.009185,
+    "M": 131.040485,
+    "C[UNIMOD:4]": 160.030649,
+    "M[UNIMOD:35]": 147.035400,
+}
+
+# Casanovo-oriented remapping
+loader = MZTabDatasetLoader(
+    residue_masses=residue_masses,
+    residue_remapping={
+        "M+15.995": "M[UNIMOD:35]",
+        "C+57.021": "C[UNIMOD:4]",
+    },
+)
 dataset = loader.load(
     data_path=Path("spectrum_data.parquet"),
     predictions_path=Path("search_results.mztab")
 )
-
-# Custom residue mapping
-custom_mapping = {"M+15.995": "M[UNIMOD:35]"}
-loader = MZTabDatasetLoader(residue_remapping=custom_mapping)
 ```
 
 #### PrimeNovoDatasetLoader
@@ -104,7 +163,36 @@ Beam predictions are not saved in PrimeNovo outputs, so the returned `Calibratio
 ```python
 from winnow.datasets.data_loaders import PrimeNovoDatasetLoader
 
-loader = PrimeNovoDatasetLoader()
+residue_masses = {
+    "G": 57.021464,
+    "A": 71.037114,
+    "C": 103.009185,
+    "M": 131.040485,
+    "C[UNIMOD:4]": 160.030649,
+    "M[UNIMOD:35]": 147.035400,
+    "[UNIMOD:1]": 42.010565,
+    "[UNIMOD:5]": 43.005814,
+    "[UNIMOD:385]": -17.026549,
+    "(+25.98)": 25.980265,
+}
+
+loader = PrimeNovoDatasetLoader(
+    residue_masses=residue_masses,
+    mid_sequence_n_terminal_mods=[
+        "[+43.006-17.027]",
+        "[+42.011]",
+        "[+43.006]",
+        "[-17.027]",
+    ],
+    residue_remapping={
+        "M[+15.995]": "M[UNIMOD:35]",
+        "C[+57.021]": "C[UNIMOD:4]",
+        "[+42.011]": "[UNIMOD:1]",
+        "[+43.006]": "[UNIMOD:5]",
+        "[-17.027]": "[UNIMOD:385]",
+        "[+43.006-17.027]": "(+25.98)",
+    },
+)
 dataset = loader.load(
     data_path=Path("spectrum_data.mgf"),
     predictions_path=Path("primenovo_predictions.tsv"),
@@ -118,7 +206,14 @@ Loads previously saved CalibrationDataset instances from Winnow's internal forma
 ```python
 from winnow.datasets.data_loaders import WinnowDatasetLoader
 
-loader = WinnowDatasetLoader()
+residue_masses = {
+    "G": 57.021464,
+    "A": 71.037114,
+    "C": 103.009185,
+    "M": 131.040485,
+}
+
+loader = WinnowDatasetLoader(residue_masses=residue_masses)
 dataset = loader.load(data_path=Path("saved_dataset_directory"))
 ```
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -51,7 +51,7 @@ dataset = mztab_loader.load(
     predictions_path=Path("predictions.mztab")
 )
 
-# Load using PrimeNovo data loader (MGF + TSV)
+# Load using pi-PrimeNovo data loader (MGF + TSV)
 primenovo_loader = PrimeNovoDatasetLoader(
     residue_masses=residue_masses,
     mid_sequence_n_terminal_mods=[
@@ -154,11 +154,11 @@ dataset = loader.load(
 
 #### PrimeNovoDatasetLoader
 
-Loads PrimeNovo predictions from a tab-separated file along with spectrum data from MGF files.
+Loads $\pi$-PrimeNovo predictions from a tab-separated file along with spectrum data from MGF files.
 
-Beam predictions are not saved in PrimeNovo outputs, so the returned `CalibrationDataset` always has `predictions=None`.
+Beam predictions are not saved in $\pi$-PrimeNovo outputs, so the returned `CalibrationDataset` always has `predictions=None`.
 
-`mid_sequence_n_terminal_mods` (see `primenovo.yaml`) lists substrings matched against the **raw** TSV `prediction` string **before** tokenisation and `residue_remapping`. Supply tokens in PrimeNovo compact notation as written in the TSV (e.g. `[+42.011]`), not remapped UNIMOD forms (e.g. `[UNIMOD:1]`). Rows with any listed mod after residue position 0 are dropped.
+`mid_sequence_n_terminal_mods` (see `primenovo.yaml`) lists substrings matched against the **raw** TSV `prediction` string **before** tokenisation and `residue_remapping`. Supply tokens in $\pi$-PrimeNovo compact notation as written in the TSV (e.g. `[+42.011]`), not remapped UNIMOD forms (e.g. `[UNIMOD:1]`). Rows with any listed mod after residue position 0 are dropped.
 
 ```python
 from winnow.datasets.data_loaders import PrimeNovoDatasetLoader
@@ -219,9 +219,9 @@ dataset = loader.load(data_path=Path("saved_dataset_directory"))
 
 #### Spectrum and prediction matching
 
-InstaNovo, MZTab, and PrimeNovo all inner-join spectrum rows and prediction rows on `spectrum_id`, but they derive that key differently.
+InstaNovo, MZTab, and $\pi$-PrimeNovo all inner-join spectrum rows and prediction rows on `spectrum_id`, but they derive that key differently.
 
-When a loader synthesises identity columns, `experiment_name` is the spectrum path stem (e.g. `spectra` for `spectra.mgf`). MZTab and PrimeNovo always use that rule, and InstaNovo uses it when synthesising IDs for MGF inputs or when `add_index_cols` is enabled for parquet/IPC.
+When a loader synthesises identity columns, `experiment_name` is the spectrum path stem (e.g. `spectra` for `spectra.mgf`). MZTab and $\pi$-PrimeNovo always use that rule, and InstaNovo uses it when synthesising IDs for MGF inputs or when `add_index_cols` is enabled for parquet/IPC.
 
 ##### Join and validation
 
@@ -236,7 +236,7 @@ Loading also raises a `ValueError` if:
 - `spectrum_id` values are not unique in the spectrum data.
 
 MZTab additionally raises if `spectra_ref` cannot be parsed (expected form `ms_run[k]:index=N`).
-PrimeNovo additionally raises if MGF `TITLE` values are missing or not unique within the file, or if a TSV `label` yields a `spectrum_id` absent from the MGF.
+$\pi$-PrimeNovo additionally raises if MGF `TITLE` values are missing or not unique within the file, or if a TSV `label` yields a `spectrum_id` absent from the MGF.
 
 ##### InstaNovo: join on `spectrum_id`
 
@@ -276,15 +276,15 @@ This is always applied for parquet, IPC, and MGF inputs; there is no config flag
 
 Use the **same** input file in the **same** order Casanovo indexed.
 
-##### PrimeNovo: join on `{experiment_name}:{title}`
+##### $\pi$-PrimeNovo: join on `{experiment_name}:{title}`
 
-PrimeNovo predictions do not carry a native `spectrum_id`. The loader builds matching IDs on both sides and then joins like InstaNovo / MZTab:
+$\pi$-PrimeNovo predictions do not carry a native `spectrum_id`. The loader builds matching IDs on both sides and then joins like InstaNovo / MZTab:
 
 1. Each MGF spectrum contributes a `title` from the MGF `TITLE` field. That value may be any non-empty string, but **must be unique within the MGF file**. Missing titles raise.
 2. Spectra receive `spectrum_id = {experiment_name}:{title}` (`experiment_name` is `Path(data_path).stem`, as for MZTab).
-3. The predictions TSV must include `label`, `prediction`, and `score` (probabilities in `[0, 1]`). PrimeNovo sets `label` from the spectrum `TITLE`, so predictions receive `spectrum_id = {experiment_name}:{label}`.
-4. Spectra and predictions are inner-joined on `spectrum_id`. Spectra without a prediction are dropped (assumed to be filtered by PrimeNovo), but orphaned predictions will raise.
-5. Before remapping, rows whose raw TSV `prediction` contains a configured mid-sequence N-terminal mod (see `mid_sequence_n_terminal_mods`) are dropped; tokens must be PrimeNovo compact notation.
+3. The predictions TSV must include `label`, `prediction`, and `score` (probabilities in `[0, 1]`). $\pi$-PrimeNovo sets `label` from the spectrum `TITLE`, so predictions receive `spectrum_id = {experiment_name}:{label}`.
+4. Spectra and predictions are inner-joined on `spectrum_id`. Spectra without a prediction are dropped (assumed to be filtered by $\pi$-PrimeNovo), but orphaned predictions will raise.
+5. Before remapping, rows whose raw TSV `prediction` contains a configured mid-sequence N-terminal mod (see `mid_sequence_n_terminal_mods`) are dropped; tokens must be $\pi$-PrimeNovo compact notation.
 
 ### PSMDataset
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -10,7 +10,12 @@ The main class for storing and processing calibration datasets for peptide seque
 
 ```python
 from winnow.datasets.calibration_dataset import CalibrationDataset
-from winnow.datasets.data_loaders import InstaNovoDatasetLoader, MZTabDatasetLoader, WinnowDatasetLoader
+from winnow.datasets.data_loaders import (
+    InstaNovoDatasetLoader,
+    MZTabDatasetLoader,
+    PrimeNovoDatasetLoader,
+    WinnowDatasetLoader,
+)
 from pathlib import Path
 
 # Load using InstaNovo data loader
@@ -25,6 +30,13 @@ mztab_loader = MZTabDatasetLoader()
 dataset = mztab_loader.load(
     data_path=Path("spectrum_data.parquet"),
     predictions_path=Path("predictions.mztab")
+)
+
+# Load using PrimeNovo data loader (MGF + TSV)
+primenovo_loader = PrimeNovoDatasetLoader()
+dataset = primenovo_loader.load(
+    data_path=Path("spectrum_data.mgf"),
+    predictions_path=Path("primenovo_predictions.tsv")
 )
 
 # Load previously saved dataset
@@ -81,6 +93,24 @@ custom_mapping = {"M+15.995": "M[UNIMOD:35]"}
 loader = MZTabDatasetLoader(residue_remapping=custom_mapping)
 ```
 
+#### PrimeNovoDatasetLoader
+
+Loads PrimeNovo predictions from a tab-separated file along with spectrum data from MGF files.
+
+Beam predictions are not saved in PrimeNovo outputs, so the returned `CalibrationDataset` always has `predictions=None`.
+
+`mid_sequence_n_terminal_mods` (see `primenovo.yaml`) lists substrings matched against the **raw** TSV `prediction` string **before** tokenisation and `residue_remapping`. Supply tokens in PrimeNovo compact notation as written in the TSV (e.g. `[+42.011]`), not remapped UNIMOD forms (e.g. `[UNIMOD:1]`). Rows with any listed mod after residue position 0 are dropped.
+
+```python
+from winnow.datasets.data_loaders import PrimeNovoDatasetLoader
+
+loader = PrimeNovoDatasetLoader()
+dataset = loader.load(
+    data_path=Path("spectrum_data.mgf"),
+    predictions_path=Path("primenovo_predictions.tsv"),
+)
+```
+
 #### WinnowDatasetLoader
 
 Loads previously saved CalibrationDataset instances from Winnow's internal format.
@@ -94,11 +124,13 @@ dataset = loader.load(data_path=Path("saved_dataset_directory"))
 
 #### Spectrum and prediction matching
 
-InstaNovo and MZTab both inner-join spectrum rows and prediction rows on `spectrum_id`, but they derive that key differently.
+InstaNovo, MZTab, and PrimeNovo all inner-join spectrum rows and prediction rows on `spectrum_id`, but they derive that key differently.
+
+When a loader synthesises identity columns, `experiment_name` is the spectrum path stem (e.g. `spectra` for `spectra.mgf`). MZTab and PrimeNovo always use that rule, and InstaNovo uses it when synthesising IDs for MGF inputs or when `add_index_cols` is enabled for parquet/IPC.
 
 ##### Join and validation
 
-Both loaders inner-join on `spectrum_id`:
+All three loaders inner-join on `spectrum_id`:
 
 - **Spectrum with no matching prediction** — dropped from the merged dataset (these are treated as spectra that did not survive filtering from the peptide sequencer).
 - **Prediction with no matching spectrum row** — loading raises a `ValueError`.
@@ -109,6 +141,7 @@ Loading also raises a `ValueError` if:
 - `spectrum_id` values are not unique in the spectrum data.
 
 MZTab additionally raises if `spectra_ref` cannot be parsed (expected form `ms_run[k]:index=N`).
+PrimeNovo additionally raises if MGF `TITLE` values are missing or not unique within the file, or if a TSV `label` yields a `spectrum_id` absent from the MGF.
 
 ##### InstaNovo: join on `spectrum_id`
 
@@ -123,9 +156,9 @@ Controls whether Winnow synthesises `experiment_name` and `spectrum_id` when loa
 
 When `add_index_cols: true`:
 
-- `experiment_name` is set to the spectrum file stem (e.g. `spectra` for `spectra.parquet`).
-- If a `scan_number` column exists, `spectrum_id` is `{file_stem}:{scan_number}`.
-- Otherwise, `spectrum_id` is `{file_stem}:{row_index}` (0-based row position in the file).
+- `experiment_name` is set to the spectrum path stem (e.g. `spectra` for `spectra.parquet`).
+- If a `scan_number` column exists, `spectrum_id` is `{experiment_name}:{scan_number}`.
+- Otherwise, `spectrum_id` is `{experiment_name}:{row_index}` (0-based row position in the file).
 
 These columns are used directly as the join key (see above).
 
@@ -147,6 +180,16 @@ The MZTab loader inner-joins spectrum rows and PSM rows on `spectrum_id` in `{ex
 This is always applied for parquet, IPC, and MGF inputs; there is no config flag.
 
 Use the **same** input file in the **same** order Casanovo indexed.
+
+##### PrimeNovo: join on `{experiment_name}:{title}`
+
+PrimeNovo predictions do not carry a native `spectrum_id`. The loader builds matching IDs on both sides and then joins like InstaNovo / MZTab:
+
+1. Each MGF spectrum contributes a `title` from the MGF `TITLE` field. That value may be any non-empty string, but **must be unique within the MGF file**. Missing titles raise.
+2. Spectra receive `spectrum_id = {experiment_name}:{title}` (`experiment_name` is `Path(data_path).stem`, as for MZTab).
+3. The predictions TSV must include `label`, `prediction`, and `score` (probabilities in `[0, 1]`). PrimeNovo sets `label` from the spectrum `TITLE`, so predictions receive `spectrum_id = {experiment_name}:{label}`.
+4. Spectra and predictions are inner-joined on `spectrum_id`. Spectra without a prediction are dropped (assumed to be filtered by PrimeNovo), but orphaned predictions will raise.
+5. Before remapping, rows whose raw TSV `prediction` contains a configured mid-sequence N-terminal mod (see `mid_sequence_n_terminal_mods`) are dropped; tokens must be PrimeNovo compact notation.
 
 ### PSMDataset
 

--- a/tests/datasets/data_loaders/test_primenovo.py
+++ b/tests/datasets/data_loaders/test_primenovo.py
@@ -1,11 +1,8 @@
 """Tests for PrimeNovoDatasetLoader: join on {experiment_name}:{title|label}."""
 
-from pathlib import Path
-
 import pandas as pd
 import polars as pl
 import pytest
-from omegaconf import OmegaConf
 
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.datasets.data_loaders import PrimeNovoDatasetLoader
@@ -113,18 +110,6 @@ class TestPrimeNovoDatasetLoader:
             }
         ).to_csv(path, sep="\t", index=False)
         with pytest.raises(ValueError, match=r"\[0, 1\]"):
-            loader._load_predictions(path)
-
-    def test_load_predictions_rejects_missing_score(self, loader, tmp_path):
-        path = tmp_path / "missing_score.tsv"
-        pd.DataFrame(
-            {
-                "label": ["a"],
-                "prediction": ["AG"],
-                "score": [None],
-            }
-        ).to_csv(path, sep="\t", index=False)
-        with pytest.raises(ValueError, match="missing score"):
             loader._load_predictions(path)
 
     def test_load_spectrum_data_sets_spectrum_id_from_title(self, loader, mgf_path):
@@ -439,10 +424,3 @@ class TestPrimeNovoDatasetLoader:
         row = meta.set_index("spectrum_id").loc["spectra:run_X_SCANS_1"]
         assert bool(row["correct"]) is True
         assert row["num_matches"] == len(row["sequence"])
-
-
-def test_primenovo_config_target() -> None:
-    """Bundled Hydra YAML points at PrimeNovoDatasetLoader."""
-    config_dir = Path(__file__).parents[3] / "winnow" / "configs"
-    cfg = OmegaConf.load(config_dir / "data_loader" / "primenovo.yaml")
-    assert cfg._target_ == "winnow.datasets.data_loaders.PrimeNovoDatasetLoader"

--- a/tests/datasets/data_loaders/test_primenovo.py
+++ b/tests/datasets/data_loaders/test_primenovo.py
@@ -1,0 +1,436 @@
+"""Tests for PrimeNovoDatasetLoader: join on {experiment_name}:{title|label}."""
+
+from pathlib import Path
+
+import pandas as pd
+import polars as pl
+import pytest
+from omegaconf import OmegaConf
+
+from winnow.datasets.calibration_dataset import CalibrationDataset
+from winnow.datasets.data_loaders import PrimeNovoDatasetLoader
+
+_PRIMENOVO_REMAPPING = {
+    "M[+15.995]": "M[UNIMOD:35]",
+    "C[+57.021]": "C[UNIMOD:4]",
+    "N[+0.984]": "N[UNIMOD:7]",
+    "Q[+0.984]": "Q[UNIMOD:7]",
+    "[+42.011]": "[UNIMOD:1]",
+    "[+43.006]": "[UNIMOD:5]",
+    "[-17.027]": "[UNIMOD:385]",
+}
+
+_MID_SEQUENCE_N_TERMINAL_MODS = [
+    "[+43.006-17.027]",
+    "[+42.011]",
+    "[+43.006]",
+    "[-17.027]",
+]
+
+
+class TestPrimeNovoDatasetLoader:
+    """Tests for PrimeNovoDatasetLoader: spectrum_id from TITLE/label, then join."""
+
+    @pytest.fixture()
+    def loader(self, full_residue_masses):
+        return PrimeNovoDatasetLoader(
+            residue_masses=full_residue_masses,
+            residue_remapping=_PRIMENOVO_REMAPPING,
+            mid_sequence_n_terminal_mods=_MID_SEQUENCE_N_TERMINAL_MODS,
+        )
+
+    @pytest.fixture()
+    def mgf_path(self, tmp_path):
+        path = tmp_path / "spectra.mgf"
+        path.write_text(
+            "BEGIN IONS\n"
+            "TITLE=run_X_SCANS_1\n"
+            "PEPMASS=358.5\n"
+            "CHARGE=3+\n"
+            "RTINSECONDS=757.5\n"
+            "SEQ=GVSREEIQR\n"
+            "100.0 1.0\n"
+            "200.0 2.0\n"
+            "END IONS\n"
+            "BEGIN IONS\n"
+            "TITLE=run_X_SCANS_2\n"
+            "PEPMASS=500.0\n"
+            "CHARGE=2+\n"
+            "RTINSECONDS=820.0\n"
+            "SEQ=YEDMNNYDPTK\n"
+            "150.0 1.5\n"
+            "END IONS\n",
+            encoding="utf-8",
+        )
+        return path
+
+    @pytest.fixture()
+    def tsv_path(self, tmp_path):
+        path = tmp_path / "denovo.tsv"
+        df = pd.DataFrame(
+            {
+                "label": ["run_X_SCANS_1", "run_X_SCANS_2"],
+                "prediction": ["GVSREELQR", "YEDM[+15.995]NNYDPTK"],
+                "charge": [3, 3],
+                "score": [0.9780, 0.0002],
+            }
+        )
+        df.to_csv(path, sep="\t", index=False)
+        return path
+
+    def test_initialization(self, loader):
+        assert loader.metrics is not None
+        assert loader.metrics.residue_set is not None
+
+    def test_load_predictions_reads_tsv(self, loader, tsv_path):
+        df = loader._load_predictions(tsv_path)
+        assert list(df.columns) == ["label", "prediction", "charge", "score"]
+        assert len(df) == 2
+
+    def test_load_predictions_rejects_unsupported_suffix(self, loader, tmp_path):
+        path = tmp_path / "preds.csv"
+        path.write_text("label\tprediction\tscore\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            loader._load_predictions(path)
+
+    def test_load_predictions_raises_on_missing_required_column(self, loader, tmp_path):
+        path = tmp_path / "missing.tsv"
+        pd.DataFrame({"label": ["a"], "prediction": ["AG"]}).to_csv(
+            path, sep="\t", index=False
+        )
+        with pytest.raises(ValueError, match="missing required column"):
+            loader._load_predictions(path)
+
+    def test_load_predictions_rejects_score_outside_unit_interval(
+        self, loader, tmp_path
+    ):
+        path = tmp_path / "bad_score.tsv"
+        pd.DataFrame(
+            {
+                "label": ["a"],
+                "prediction": ["AG"],
+                "score": [1.5],
+            }
+        ).to_csv(path, sep="\t", index=False)
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            loader._load_predictions(path)
+
+    def test_load_spectrum_data_sets_spectrum_id_from_title(self, loader, mgf_path):
+        df, has_labels = loader._load_spectrum_data(mgf_path)
+        assert has_labels is True
+        assert df["spectrum_id"].to_list() == [
+            "spectra:run_X_SCANS_1",
+            "spectra:run_X_SCANS_2",
+        ]
+        assert df["experiment_name"].to_list() == ["spectra", "spectra"]
+        assert df["title"].to_list() == ["run_X_SCANS_1", "run_X_SCANS_2"]
+
+    def test_load_spectrum_data_rejects_unsupported_suffix(self, loader, tmp_path):
+        path = tmp_path / "spec.csv"
+        path.write_text("col\n1\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            loader._load_spectrum_data(path)
+
+    def test_load_spectrum_data_raises_on_duplicate_titles(self, loader, tmp_path):
+        path = tmp_path / "dup.mgf"
+        path.write_text(
+            "BEGIN IONS\nTITLE=same\nPEPMASS=100\nCHARGE=2+\n100.0 1.0\nEND IONS\n"
+            "BEGIN IONS\nTITLE=same\nPEPMASS=200\nCHARGE=2+\n200.0 1.0\nEND IONS\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="TITLE values must be unique"):
+            loader._load_spectrum_data(path)
+
+    def test_load_spectrum_data_raises_on_missing_title(self, loader, tmp_path):
+        path = tmp_path / "missing_title.mgf"
+        path.write_text(
+            "BEGIN IONS\nPEPMASS=100\nCHARGE=2+\n100.0 1.0\nEND IONS\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="non-empty TITLE"):
+            loader._load_spectrum_data(path)
+
+    def test_add_prediction_spectrum_ids_uses_label(self, loader):
+        preds = pl.DataFrame(
+            {"label": ["t1", "t2"], "prediction": ["AG", "MG"], "score": [0.9, 0.5]}
+        )
+        result = loader._add_prediction_spectrum_ids(preds, "spectra")
+        assert result["spectrum_id"].to_list() == ["spectra:t1", "spectra:t2"]
+        assert result["label"].to_list() == ["t1", "t2"]
+
+    def test_process_predictions_renames_score_and_sets_untokenised(self, loader):
+        preds = pl.DataFrame(
+            {
+                "label": ["t1"],
+                "prediction": ["YEDM[+15.995]NNYDPTK"],
+                "score": [0.42],
+            }
+        )
+        result = loader._process_predictions(preds, [], "spectra")
+        assert result["confidence"].to_list() == pytest.approx([0.42])
+        assert result["prediction_untokenised"].to_list() == ["YEDM[+15.995]NNYDPTK"]
+        assert result["spectrum_id"].to_list() == ["spectra:t1"]
+        assert "score" not in result.columns
+
+    def test_process_predictions_preserves_l_in_prediction_untokenised(self, loader):
+        preds = pl.DataFrame(
+            {
+                "label": ["t"],
+                "prediction": ["GVSREELQR"],
+                "score": [0.5],
+            }
+        )
+        result = loader._process_predictions(preds, [], "spectra")
+        assert result["prediction_untokenised"].to_list() == ["GVSREELQR"]
+
+    def test_process_predictions_filters_mid_sequence_nterm_mods(self, loader):
+        preds = pl.DataFrame(
+            {
+                "label": ["a", "b"],
+                "prediction": ["AG[+42.011]K", "AG"],
+                "score": [0.1, 0.9],
+            }
+        )
+        result = loader._process_predictions(preds, [], "spectra")
+        assert result["prediction"].to_list() == ["AG"]
+        assert len(result) == 1
+
+    def test_process_predictions_respects_configured_nterm_mods(
+        self, full_residue_masses
+    ):
+        loader = PrimeNovoDatasetLoader(
+            residue_masses=full_residue_masses,
+            residue_remapping=_PRIMENOVO_REMAPPING,
+            mid_sequence_n_terminal_mods=["[+99.000]"],
+        )
+        preds = pl.DataFrame(
+            {
+                "label": ["a", "b"],
+                "prediction": ["AG[+42.011]K", "A[+99.000]G"],
+                "score": [0.1, 0.9],
+            }
+        )
+        result = loader._process_predictions(preds, [], "spectra")
+        # Default acetylation mid-seq is no longer filtered; custom mod is.
+        assert result["prediction"].to_list() == ["AG[+42.011]K"]
+        assert len(result) == 1
+
+    def test_process_predictions_drops_clashing_prediction_columns(self, loader):
+        preds = pl.DataFrame(
+            {
+                "label": ["t1"],
+                "prediction": ["AG"],
+                "score": [0.9],
+                "experiment_name": ["wrong"],
+            }
+        )
+        result = loader._process_predictions(
+            preds, ["spectrum_id", "title", "experiment_name"], "spectra"
+        )
+        assert "experiment_name" not in result.columns
+        assert result["spectrum_id"].to_list() == ["spectra:t1"]
+
+    def test_merge_data_joins_on_spectrum_id(self, loader):
+        preds = loader._process_predictions(
+            pl.DataFrame(
+                {
+                    "label": ["t1", "t2"],
+                    "prediction": ["AG", "MG"],
+                    "score": [0.9, 0.5],
+                }
+            ),
+            ["spectrum_id", "experiment_name", "title", "mz_array"],
+            "spectra",
+        )
+        spectra = pl.DataFrame(
+            {
+                "spectrum_id": ["spectra:t1", "spectra:t2"],
+                "experiment_name": ["spectra", "spectra"],
+                "title": ["t1", "t2"],
+                "mz_array": [[1.0], [2.0]],
+            }
+        )
+        merged = loader._merge_data(spectra, preds)
+        assert len(merged) == 2
+        assert merged["spectrum_id"].to_list() == ["spectra:t1", "spectra:t2"]
+        assert merged["label"].to_list() == ["t1", "t2"]
+        assert "mz_array" in merged.columns
+
+    def test_merge_data_raises_when_no_matches(self, loader):
+        preds = loader._process_predictions(
+            pl.DataFrame(
+                {
+                    "label": ["t1", "t2"],
+                    "prediction": ["AG", "MG"],
+                    "score": [0.9, 0.5],
+                }
+            ),
+            ["spectrum_id", "experiment_name", "title", "mz_array"],
+            "spectra",
+        )
+        spectra = pl.DataFrame(
+            {
+                "spectrum_id": ["spectra:other"],
+                "experiment_name": ["spectra"],
+                "title": ["other"],
+                "mz_array": [[1.0]],
+            }
+        )
+        with pytest.raises(ValueError, match="spectrum_id values not present"):
+            loader._merge_data(spectra, preds)
+
+    def test_merge_data_raises_on_orphan_prediction(self, loader):
+        preds = loader._process_predictions(
+            pl.DataFrame(
+                {
+                    "label": ["t1", "missing"],
+                    "prediction": ["AG", "MG"],
+                    "score": [0.9, 0.5],
+                }
+            ),
+            ["spectrum_id", "experiment_name", "title", "mz_array"],
+            "spectra",
+        )
+        spectra = pl.DataFrame(
+            {
+                "spectrum_id": ["spectra:t1"],
+                "experiment_name": ["spectra"],
+                "title": ["t1"],
+                "mz_array": [[1.0]],
+            }
+        )
+        with pytest.raises(ValueError, match="spectrum_id values not present"):
+            loader._merge_data(spectra, preds)
+
+    def test_merge_data_raises_on_duplicate_prediction_labels(self, loader):
+        preds = loader._process_predictions(
+            pl.DataFrame(
+                {
+                    "label": ["t1", "t1"],
+                    "prediction": ["AG", "MG"],
+                    "score": [0.9, 0.5],
+                }
+            ),
+            ["spectrum_id", "experiment_name", "title", "mz_array"],
+            "spectra",
+        )
+        spectra = pl.DataFrame(
+            {
+                "spectrum_id": ["spectra:t1"],
+                "experiment_name": ["spectra"],
+                "title": ["t1"],
+                "mz_array": [[1.0]],
+            }
+        )
+        with pytest.raises(ValueError, match="duplicate TSV label"):
+            loader._merge_data(spectra, preds)
+
+    def test_merge_data_prefers_spectrum_experiment_name(self, loader):
+        preds = loader._process_predictions(
+            pl.DataFrame(
+                {
+                    "label": ["t1"],
+                    "prediction": ["AG"],
+                    "score": [0.9],
+                    "experiment_name": ["wrong"],
+                }
+            ),
+            ["spectrum_id", "title", "experiment_name"],
+            "spectra",
+        )
+        spectra = pl.DataFrame(
+            {
+                "spectrum_id": ["spectra:t1"],
+                "title": ["t1"],
+                "experiment_name": ["spectra"],
+            }
+        )
+        merged = loader._merge_data(spectra, preds)
+        assert merged["experiment_name"].to_list() == ["spectra"]
+
+    def test_load_raises_when_predictions_path_is_none(self, loader, tmp_path):
+        with pytest.raises(ValueError, match="predictions_path is required"):
+            loader.load(data_path=tmp_path)
+
+    def test_load_returns_calibration_dataset_without_beams(
+        self, loader, mgf_path, tsv_path
+    ):
+        dataset = loader.load(data_path=mgf_path, predictions_path=tsv_path)
+        assert isinstance(dataset, CalibrationDataset)
+        assert dataset.predictions is None
+
+    def test_load_aligns_on_spectrum_id(self, loader, mgf_path, tsv_path):
+        dataset = loader.load(data_path=mgf_path, predictions_path=tsv_path)
+        meta = dataset.metadata
+        assert len(meta) == 2
+        assert meta["spectrum_id"].tolist() == [
+            "spectra:run_X_SCANS_1",
+            "spectra:run_X_SCANS_2",
+        ]
+        assert meta["label"].tolist() == ["run_X_SCANS_1", "run_X_SCANS_2"]
+        assert all(isinstance(p, list) for p in meta["prediction"])
+        assert "score" not in meta.columns
+        assert meta["confidence"].between(0.0, 1.0).all()
+
+    def test_load_tokenises_and_remaps_via_finalize(self, loader, mgf_path, tsv_path):
+        dataset = loader.load(data_path=mgf_path, predictions_path=tsv_path)
+        meta = dataset.metadata
+        row = meta.set_index("spectrum_id").loc["spectra:run_X_SCANS_2"]
+        assert "M[UNIMOD:35]" in row["prediction"]
+        assert "M[+15.995]" in row["prediction_untokenised"]
+
+    def test_load_applies_token_level_l_to_i(self, loader, mgf_path, tsv_path):
+        dataset = loader.load(data_path=mgf_path, predictions_path=tsv_path)
+        meta = dataset.metadata
+        row = meta.set_index("spectrum_id").loc["spectra:run_X_SCANS_1"]
+        assert "L" not in row["prediction"]
+        assert "L" in row["prediction_untokenised"]
+
+    def test_load_inner_join_keeps_only_matching_spectrum_ids(
+        self, loader, mgf_path, tmp_path
+    ):
+        path = tmp_path / "short.tsv"
+        pd.DataFrame(
+            {
+                "label": ["run_X_SCANS_1"],
+                "prediction": ["GVSREELQR"],
+                "charge": [3],
+                "score": [0.978],
+            }
+        ).to_csv(path, sep="\t", index=False)
+        dataset = loader.load(data_path=mgf_path, predictions_path=path)
+        assert len(dataset.metadata) == 1
+        assert dataset.metadata["spectrum_id"].tolist() == ["spectra:run_X_SCANS_1"]
+
+    def test_load_raises_when_label_has_no_matching_title(
+        self, loader, mgf_path, tmp_path
+    ):
+        path = tmp_path / "bad.tsv"
+        pd.DataFrame(
+            {
+                "label": ["not_in_mgf"],
+                "prediction": ["GVSREELQR"],
+                "charge": [3],
+                "score": [0.978],
+            }
+        ).to_csv(path, sep="\t", index=False)
+        with pytest.raises(ValueError, match="spectrum_id values not present"):
+            loader.load(data_path=mgf_path, predictions_path=path)
+
+    def test_load_evaluates_against_ground_truth(self, loader, mgf_path, tsv_path):
+        dataset = loader.load(data_path=mgf_path, predictions_path=tsv_path)
+        meta = dataset.metadata
+        assert "valid_sequence" in meta.columns
+        assert "valid_prediction" in meta.columns
+        assert "num_matches" in meta.columns
+        assert "correct" in meta.columns
+        row = meta.set_index("spectrum_id").loc["spectra:run_X_SCANS_1"]
+        assert bool(row["correct"]) is True
+        assert row["num_matches"] == len(row["sequence"])
+
+
+def test_primenovo_config_target() -> None:
+    """Bundled Hydra YAML points at PrimeNovoDatasetLoader."""
+    config_dir = Path(__file__).parents[3] / "winnow" / "configs"
+    cfg = OmegaConf.load(config_dir / "data_loader" / "primenovo.yaml")
+    assert cfg._target_ == "winnow.datasets.data_loaders.PrimeNovoDatasetLoader"

--- a/tests/datasets/data_loaders/test_primenovo.py
+++ b/tests/datasets/data_loaders/test_primenovo.py
@@ -115,6 +115,18 @@ class TestPrimeNovoDatasetLoader:
         with pytest.raises(ValueError, match=r"\[0, 1\]"):
             loader._load_predictions(path)
 
+    def test_load_predictions_rejects_missing_score(self, loader, tmp_path):
+        path = tmp_path / "missing_score.tsv"
+        pd.DataFrame(
+            {
+                "label": ["a"],
+                "prediction": ["AG"],
+                "score": [None],
+            }
+        ).to_csv(path, sep="\t", index=False)
+        with pytest.raises(ValueError, match="missing score"):
+            loader._load_predictions(path)
+
     def test_load_spectrum_data_sets_spectrum_id_from_title(self, loader, mgf_path):
         df, has_labels = loader._load_spectrum_data(mgf_path)
         assert has_labels is True

--- a/tests/datasets/data_loaders/test_utils.py
+++ b/tests/datasets/data_loaders/test_utils.py
@@ -373,3 +373,56 @@ class TestFinalizePeptideMetadata:
         )
         assert metadata["valid_prediction"].iloc[0]
         assert "valid_sequence" not in metadata.columns
+
+    def test_none_or_nan_score_marks_prediction_invalid(self, metrics: Metrics) -> None:
+        metadata = pd.DataFrame(
+            {
+                "sequence": [["P", "E"], ["P", "E"], ["P", "E"]],
+                "prediction": [["P", "E"], ["P", "E"], ["P", "E"]],
+                "confidence": [0.9, None, float("nan")],
+            }
+        )
+        data_utils.finalize_peptide_metadata(
+            metadata,
+            metrics,
+            has_labels=True,
+            residue_remapping=REMAPPING,
+        )
+        assert metadata["valid_prediction"].tolist() == [True, False, False]
+        assert metadata["correct"].tolist() == [True, False, False]
+        assert metadata["num_matches"].tolist() == [2, 0, 0]
+
+    def test_polars_none_or_nan_score_marks_prediction_invalid(
+        self, metrics: Metrics
+    ) -> None:
+        metadata = pl.DataFrame(
+            {
+                "sequence": [["P", "E"], ["P", "E"], ["P", "E"]],
+                "prediction": [["P", "E"], ["P", "E"], ["P", "E"]],
+                "confidence": [0.9, None, float("nan")],
+            }
+        )
+        result = data_utils.finalize_peptide_metadata(
+            metadata,
+            metrics,
+            has_labels=True,
+            residue_remapping=REMAPPING,
+        )
+        assert result["valid_prediction"].to_list() == [True, False, False]
+        assert result["correct"].to_list() == [True, False, False]
+        assert result["num_matches"].to_list() == [2, 0, 0]
+
+    def test_missing_score_column_skips_score_check(self, metrics: Metrics) -> None:
+        metadata = pd.DataFrame(
+            {
+                "sequence": [["P", "E"]],
+                "prediction": [["P", "E"]],
+            }
+        )
+        data_utils.finalize_peptide_metadata(
+            metadata,
+            metrics,
+            has_labels=True,
+            residue_remapping=REMAPPING,
+        )
+        assert metadata["valid_prediction"].iloc[0]

--- a/winnow/configs/compute_features.yaml
+++ b/winnow/configs/compute_features.yaml
@@ -3,7 +3,7 @@ defaults:
   - _self_
   - residues
   - calibrator
-  - data_loader: instanovo  # Options: instanovo, mztab, pointnovo, winnow
+  - data_loader: instanovo  # Options: instanovo, mztab, pointnovo, primenovo, winnow
 
 dataset:
   # Dataset paths (same as train):

--- a/winnow/configs/data_loader/primenovo.yaml
+++ b/winnow/configs/data_loader/primenovo.yaml
@@ -1,0 +1,30 @@
+# --- PrimeNovo data loading configuration ---
+_target_: winnow.datasets.data_loaders.PrimeNovoDatasetLoader
+
+residue_masses: ${residue_masses}
+
+residue_remapping:  # Used to map PrimeNovo-specific notations to UNIMOD tokens.
+  "M[+15.995]": "M[UNIMOD:35]"  # Oxidation
+  "C[+57.021]": "C[UNIMOD:4]"  # Carbamidomethylation
+  "N[+0.984]": "N[UNIMOD:7]"  # Deamidation
+  "Q[+0.984]": "Q[UNIMOD:7]"  # Deamidation
+  "[+42.011]": "[UNIMOD:1]"  # Acetylation
+  "[+43.006]": "[UNIMOD:5]"  # Carbamylation
+  "[-17.027]": "[UNIMOD:385]"  # Ammonia loss
+  "[+43.006-17.027]": "(+25.98)"  # Carbamylation & NH3 loss
+  "C[Carbamidomethyl]": "C[UNIMOD:4]"  # Carbamidomethylation
+  "M[Oxidation]": "M[UNIMOD:35]"  # Oxidation
+  "N[Deamidated]": "N[UNIMOD:7]"  # Deamidation
+  "Q[Deamidated]": "Q[UNIMOD:7]"  # Deamidation
+  "[Acetyl]": "[UNIMOD:1]"  # Acetylation
+  "[Carbamyl]": "[UNIMOD:5]"  # Carbamylation
+
+# Matched as substrings of the raw TSV `prediction` column BEFORE residue_remapping
+# and tokenisation. Use PrimeNovo compact notation as written in the TSV
+# (e.g. "[+42.011]"), not remapped UNIMOD / ProForma forms (e.g. "[UNIMOD:1]").
+# Rows with any listed mod after residue position 0 are dropped.
+mid_sequence_n_terminal_mods:
+  - "[+43.006-17.027]"  # Carbamylation & NH3 loss
+  - "[+42.011]"  # Acetylation
+  - "[+43.006]"  # Carbamylation
+  - "[-17.027]"  # Ammonia loss

--- a/winnow/configs/data_loader/primenovo.yaml
+++ b/winnow/configs/data_loader/primenovo.yaml
@@ -1,9 +1,9 @@
-# --- PrimeNovo data loading configuration ---
+# --- pi-PrimeNovo data loading configuration ---
 _target_: winnow.datasets.data_loaders.PrimeNovoDatasetLoader
 
 residue_masses: ${residue_masses}
 
-residue_remapping:  # Used to map PrimeNovo-specific notations to UNIMOD tokens.
+residue_remapping:  # Used to map pi-PrimeNovo-specific notations to UNIMOD tokens.
   "M[+15.995]": "M[UNIMOD:35]"  # Oxidation
   "C[+57.021]": "C[UNIMOD:4]"  # Carbamidomethylation
   "N[+0.984]": "N[UNIMOD:7]"  # Deamidation
@@ -20,7 +20,7 @@ residue_remapping:  # Used to map PrimeNovo-specific notations to UNIMOD tokens.
   "[Carbamyl]": "[UNIMOD:5]"  # Carbamylation
 
 # Matched as substrings of the raw TSV `prediction` column BEFORE residue_remapping
-# and tokenisation. Use PrimeNovo compact notation as written in the TSV
+# and tokenisation. Use pi-PrimeNovo compact notation as written in the TSV
 # (e.g. "[+42.011]"), not remapped UNIMOD / ProForma forms (e.g. "[UNIMOD:1]").
 # Rows with any listed mod after residue position 0 are dropped.
 mid_sequence_n_terminal_mods:

--- a/winnow/configs/predict.yaml
+++ b/winnow/configs/predict.yaml
@@ -3,7 +3,7 @@ defaults:
   - _self_
   - residues
   - koina
-  - data_loader: instanovo  # Options: instanovo, mztab, pointnovo, winnow
+  - data_loader: instanovo  # Options: instanovo, mztab, pointnovo, primenovo, winnow
   - fdr_method: nonparametric  # Options: nonparametric, database_grounded
 
 # --- Pipeline Execution Configuration ---

--- a/winnow/configs/train.yaml
+++ b/winnow/configs/train.yaml
@@ -3,7 +3,7 @@ defaults:
   - _self_
   - residues
   - calibrator
-  - data_loader: instanovo  # Options: instanovo, mztab, pointnovo, winnow
+  - data_loader: instanovo  # Options: instanovo, mztab, pointnovo, primenovo, winnow
 
 # --- Pipeline Execution Configuration ---
 

--- a/winnow/datasets/data_loaders/__init__.py
+++ b/winnow/datasets/data_loaders/__init__.py
@@ -1,13 +1,15 @@
-"""Dataset loaders for InstaNovo, mzTab, PointNovo, and saved Winnow datasets."""
+"""Dataset loaders for InstaNovo, mzTab, PointNovo, PrimeNovo, and saved Winnow datasets."""
 
 from winnow.datasets.data_loaders.instanovo import InstaNovoDatasetLoader
 from winnow.datasets.data_loaders.mztab import MZTabDatasetLoader
 from winnow.datasets.data_loaders.pointnovo import PointNovoDatasetLoader
+from winnow.datasets.data_loaders.primenovo import PrimeNovoDatasetLoader
 from winnow.datasets.data_loaders.winnow import WinnowDatasetLoader
 
 __all__ = [
     "InstaNovoDatasetLoader",
     "MZTabDatasetLoader",
     "PointNovoDatasetLoader",
+    "PrimeNovoDatasetLoader",
     "WinnowDatasetLoader",
 ]

--- a/winnow/datasets/data_loaders/__init__.py
+++ b/winnow/datasets/data_loaders/__init__.py
@@ -1,4 +1,4 @@
-"""Dataset loaders for InstaNovo, mzTab, PointNovo, PrimeNovo, and saved Winnow datasets."""
+"""Dataset loaders for InstaNovo, mzTab, PointNovo, pi-PrimeNovo, and saved Winnow datasets."""
 
 from winnow.datasets.data_loaders.instanovo import InstaNovoDatasetLoader
 from winnow.datasets.data_loaders.mztab import MZTabDatasetLoader

--- a/winnow/datasets/data_loaders/mztab.py
+++ b/winnow/datasets/data_loaders/mztab.py
@@ -289,13 +289,33 @@ class MZTabDatasetLoader(DatasetLoader):
     def load(
         self, *, data_path: Path, predictions_path: Optional[Path] = None, **kwargs: Any
     ) -> CalibrationDataset:
-        """Load a calibration dataset from mzTab predictions and spectrum data."""
+        """Load a CalibrationDataset from mzTab PSM tables and spectrum data.
+
+        Args:
+            data_path: Path to the spectrum data file (``.parquet``, ``.ipc``, or
+                ``.mgf``).
+            predictions_path: Path to the mzTab predictions file (``.mztab``).
+            **kwargs: Not used.
+
+        Returns:
+            CalibrationDataset: Dataset containing merged metadata. For Casanovo
+                mzTab with ``load_beams=True``, ``predictions`` holds per-spectrum
+                beam lists; otherwise ``predictions`` is ``None``.
+
+        Raises:
+            ValueError: If ``predictions_path`` is None, the predictions path is
+                not ``.mztab``, required mzTab columns are missing or
+                ``spectra_ref`` cannot be parsed, ``load_beams=True`` is set for
+                non-Casanovo mzTab, Casanovo PSM or token scores are outside their
+                expected ranges, spectrum ``spectrum_id`` values are missing or
+                not unique, or predictions reference spectrum IDs with no match
+                in the spectrum data.
+        """
         if predictions_path is None:
             raise ValueError("predictions_path is required for MZTabDatasetLoader")
 
         experiment_name = Path(data_path).stem
         spectrum_data, has_labels = self._load_spectrum_data(data_path)
-        spectrum_data = self._process_spectrum_data(spectrum_data)
 
         raw_predictions = self._load_dataset(predictions_path)
         is_casanovo = self._is_casanovo_mztab(raw_predictions)
@@ -472,10 +492,6 @@ class MZTabDatasetLoader(DatasetLoader):
                 )
             beam_predictions.append(scored_sequences or None)
         return beam_predictions
-
-    def _process_spectrum_data(self, spectrum_data: pl.DataFrame) -> pl.DataFrame:
-        """Return spectrum data unchanged; tokenization happens in finalize."""
-        return spectrum_data
 
     def _merge_data(
         self, spectrum_data: pl.DataFrame, predictions: pl.DataFrame

--- a/winnow/datasets/data_loaders/primenovo.py
+++ b/winnow/datasets/data_loaders/primenovo.py
@@ -1,9 +1,9 @@
-"""PrimeNovo TSV + MGF dataset loader.
+"""pi-PrimeNovo TSV + MGF dataset loader.
 
 Spectrum-prediction linking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Spectra are loaded from ``.mgf`` with matchms. Each ion's matchms ``title`` comes
-from the MGF ``TITLE`` field and may be any non-empty string; PrimeNovo copies
+from the MGF ``TITLE`` field and may be any non-empty string; pi-PrimeNovo copies
 that value into the TSV ``label`` column. Within one MGF file, ``TITLE`` values
 must be unique.
 
@@ -20,7 +20,7 @@ predictions whose ``label`` does not match any spectrum ``TITLE`` raise.
 
 Score assumptions
 ~~~~~~~~~~~~~~~~~
-PrimeNovo ``score`` values are probabilities in ``[0, 1]`` and are stored as
+pi-PrimeNovo ``score`` values are probabilities in ``[0, 1]`` and are stored as
 ``confidence`` without transformation. Values outside this range raise at load
 time.
 
@@ -28,14 +28,14 @@ Mid-sequence N-terminal modification filtering
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``mid_sequence_n_terminal_mods`` lists substrings matched against the **raw**
 TSV ``prediction`` string **before** tokenisation and ``residue_remapping``.
-Supply tokens in PrimeNovo compact notation as written in the TSV (e.g.
+Supply tokens in pi-PrimeNovo compact notation as written in the TSV (e.g.
 ``[+42.011]``), not remapped UNIMOD / ProForma forms (e.g. ``[UNIMOD:1]``).
 Rows whose prediction contains any listed mod after residue position 0 are
 dropped.
 
 Beams
 ~~~~~
-PrimeNovo does not emit beam predictions, so the returned
+pi-PrimeNovo does not emit beam predictions, so the returned
 :class:`~winnow.datasets.calibration_dataset.CalibrationDataset` always has
 ``predictions=None``.
 """
@@ -58,25 +58,25 @@ logger = logging.getLogger(__name__)
 
 
 class PrimeNovoDatasetLoader(DatasetLoader):
-    """Loader for PrimeNovo predictions in TSV format.
+    """Loader for pi-PrimeNovo predictions in TSV format.
 
-    PrimeNovo writes predictions to a tab-separated file with fixed columns
+    pi-PrimeNovo writes predictions to a tab-separated file with fixed columns
     ``label``, ``prediction``, ``charge``, ``score``. Spectra (``.mgf``) are loaded
     with matchms. ``spectrum_id`` is ``{experiment_name}:{title}`` on the MGF side and
-    ``{experiment_name}:{label}`` on the TSV side (PrimeNovo sets TSV ``label`` from the
+    ``{experiment_name}:{label}`` on the TSV side (pi-PrimeNovo sets TSV ``label`` from the
     MGF ``TITLE``). Titles and labels may be any non-empty string but must each be
     unique within their file. Tables are inner-joined on ``spectrum_id``.
 
     Score values are already probabilities in ``[0, 1]`` and are stored as
     ``confidence`` without transformation. Beam predictions are not available from
-    PrimeNovo, so the returned :class:`CalibrationDataset` always has
+    pi-PrimeNovo, so the returned :class:`CalibrationDataset` always has
     ``predictions=None``.
 
     ``mid_sequence_n_terminal_mods`` are matched as substrings of the raw TSV
-    ``prediction`` before remapping; use PrimeNovo compact notation, not UNIMOD.
+    ``prediction`` before remapping; use pi-PrimeNovo compact notation, not UNIMOD.
     """
 
-    # Score encoding: PrimeNovo ``score`` is a probability
+    # Score encoding: pi-PrimeNovo ``score`` is a probability
     _SCORE_MIN = 0.0
     _SCORE_MAX = 1.0
 
@@ -94,9 +94,9 @@ class PrimeNovoDatasetLoader(DatasetLoader):
             mid_sequence_n_terminal_mods: N-terminal modification tokens that are
                 invalid if they appear after residue position 0. Matched as
                 substrings of the raw TSV ``prediction`` **before**
-                ``residue_remapping``; use PrimeNovo compact notation (e.g.
+                ``residue_remapping``; use pi-PrimeNovo compact notation (e.g.
                 ``[+42.011]``), not remapped UNIMOD forms. Matching rows are dropped.
-            residue_remapping: Optional ProForma mapping from PrimeNovo tokens.
+            residue_remapping: Optional ProForma mapping from pi-PrimeNovo tokens.
             isotope_error_range: The range of isotope errors to consider when matching
                 peptides.
         """
@@ -155,25 +155,25 @@ class PrimeNovoDatasetLoader(DatasetLoader):
 
     @classmethod
     def _validate_primenovo_score(cls, score: float) -> None:
-        """Raise if a PrimeNovo score is outside ``[0, 1]``."""
+        """Raise if a pi-PrimeNovo score is outside ``[0, 1]``."""
         if not cls._SCORE_MIN <= score <= cls._SCORE_MAX:
             raise ValueError(
-                f"PrimeNovo scores must be probabilities in [0, 1]. Got {score}."
+                f"pi-PrimeNovo scores must be probabilities in [0, 1]. Got {score}."
             )
 
     def load(
         self, *, data_path: Path, predictions_path: Optional[Path] = None, **kwargs: Any
     ) -> CalibrationDataset:
-        """Load a CalibrationDataset from PrimeNovo TSV predictions and MGF spectra.
+        """Load a CalibrationDataset from pi-PrimeNovo TSV predictions and MGF spectra.
 
         Args:
             data_path: Path to the spectrum data file (``.mgf`` only).
-            predictions_path: Path to the PrimeNovo predictions TSV file.
+            predictions_path: Path to the pi-PrimeNovo predictions TSV file.
             **kwargs: Not used.
 
         Returns:
             CalibrationDataset: Dataset containing merged metadata. ``predictions`` is
-                always ``None`` because PrimeNovo does not produce beams.
+                always ``None`` because pi-PrimeNovo does not produce beams.
 
         Raises:
             ValueError: If ``predictions_path`` is None, required TSV columns are
@@ -222,7 +222,7 @@ class PrimeNovoDatasetLoader(DatasetLoader):
     ) -> pl.DataFrame:
         """Set prediction ``spectrum_id`` to ``{experiment_name}:{label}``.
 
-        PrimeNovo sets TSV ``label`` from the MGF ``TITLE``, so ids match
+        pi-PrimeNovo sets TSV ``label`` from the MGF ``TITLE``, so ids match
         ``{experiment_name}:{title}`` on the spectrum side.
         """
         predictions = predictions.with_columns(
@@ -240,7 +240,7 @@ class PrimeNovoDatasetLoader(DatasetLoader):
         empty_labels = predictions.filter(pl.col("label").is_null())
         if len(empty_labels) > 0:
             raise ValueError(
-                "PrimeNovo predictions contain empty label values; label must equal "
+                "pi-PrimeNovo predictions contain empty label values; label must equal "
                 "the corresponding MGF TITLE."
             )
 
@@ -263,7 +263,7 @@ class PrimeNovoDatasetLoader(DatasetLoader):
         return False
 
     def _load_predictions(self, predictions_path: Path | str) -> pl.DataFrame:
-        """Load PrimeNovo TSV predictions and validate required columns and scores.
+        """Load pi-PrimeNovo TSV predictions and validate required columns and scores.
 
         Args:
             predictions_path: Path to the predictions TSV or TXT file.
@@ -279,7 +279,7 @@ class PrimeNovoDatasetLoader(DatasetLoader):
         predictions_path = Path(predictions_path)
         if predictions_path.suffix not in {".tsv", ".txt"}:
             raise ValueError(
-                f"Unsupported file format for PrimeNovo predictions: "
+                f"Unsupported file format for pi-PrimeNovo predictions: "
                 f"{predictions_path.suffix}. Supported formats are .tsv and .txt."
             )
         predictions = pl.read_csv(predictions_path, separator="\t")
@@ -288,7 +288,7 @@ class PrimeNovoDatasetLoader(DatasetLoader):
         missing = [col for col in required if col not in predictions.columns]
         if missing:
             raise ValueError(
-                f"PrimeNovo predictions file is missing required column(s): {missing}. "
+                f"pi-PrimeNovo predictions file is missing required column(s): {missing}. "
                 f"Present columns: {list(predictions.columns)}."
             )
 
@@ -345,7 +345,7 @@ class PrimeNovoDatasetLoader(DatasetLoader):
         missing_titles = df.filter(pl.col("title").is_null())
         if len(missing_titles) > 0:
             raise ValueError(
-                "PrimeNovo MGF spectra require a non-empty TITLE for every ion. "
+                "pi-PrimeNovo MGF spectra require a non-empty TITLE for every ion. "
                 f"Missing TITLE on {len(missing_titles)} spectrum row(s)."
             )
         if df["title"].n_unique() != len(df):
@@ -382,7 +382,7 @@ class PrimeNovoDatasetLoader(DatasetLoader):
 
         if merged.height == 0:
             raise ValueError(
-                "PrimeNovo inner join on spectrum_id produced no rows. Ensure each "
+                "pi-PrimeNovo inner join on spectrum_id produced no rows. Ensure each "
                 "TSV label equals the corresponding spectrum TITLE in the MGF."
             )
         if merged.height != predictions.height:
@@ -415,7 +415,7 @@ class PrimeNovoDatasetLoader(DatasetLoader):
         n_bad = int(bad_mask.sum())
         if n_bad:
             logger.warning(
-                "Filtered %d spectra with PrimeNovo N-terminal modifications "
+                "Filtered %d spectra with pi-PrimeNovo N-terminal modifications "
                 "incorrectly placed in the middle of the peptide sequence.",
                 n_bad,
             )

--- a/winnow/datasets/data_loaders/primenovo.py
+++ b/winnow/datasets/data_loaders/primenovo.py
@@ -1,0 +1,435 @@
+"""PrimeNovo TSV + MGF dataset loader.
+
+Spectrum-prediction linking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Spectra are loaded from ``.mgf`` with matchms. Each ion's matchms ``title`` comes
+from the MGF ``TITLE`` field and may be any non-empty string; PrimeNovo copies
+that value into the TSV ``label`` column. Within one MGF file, ``TITLE`` values
+must be unique.
+
+Both sides receive the same ``spectrum_id`` form before joining:
+
+* MGF: ``{experiment_name}:{title}``
+* TSV: ``{experiment_name}:{label}``
+
+where ``experiment_name`` is the spectrum path stem (``Path(data_path).stem``).
+``TITLE`` values must be unique within one MGF file, and TSV ``label`` values
+must be unique within the predictions file. The tables are then inner-joined on
+``spectrum_id`` (InstaNovo standard): spectra without a prediction are dropped;
+predictions whose ``label`` does not match any spectrum ``TITLE`` raise.
+
+Score assumptions
+~~~~~~~~~~~~~~~~~
+PrimeNovo ``score`` values are probabilities in ``[0, 1]`` and are stored as
+``confidence`` without transformation. Values outside this range raise at load
+time.
+
+Mid-sequence N-terminal modification filtering
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``mid_sequence_n_terminal_mods`` lists substrings matched against the **raw**
+TSV ``prediction`` string **before** tokenisation and ``residue_remapping``.
+Supply tokens in PrimeNovo compact notation as written in the TSV (e.g.
+``[+42.011]``), not remapped UNIMOD / ProForma forms (e.g. ``[UNIMOD:1]``).
+Rows whose prediction contains any listed mod after residue position 0 are
+dropped.
+
+Beams
+~~~~~
+PrimeNovo does not emit beam predictions, so the returned
+:class:`~winnow.datasets.calibration_dataset.CalibrationDataset` always has
+``predictions=None``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+import polars as pl
+from instanovo.utils.metrics import Metrics
+from instanovo.utils.residues import ResidueSet
+
+from winnow.datasets.calibration_dataset import CalibrationDataset
+from winnow.datasets.data_loaders import utils as data_utils
+from winnow.datasets.interfaces import DatasetLoader
+
+logger = logging.getLogger(__name__)
+
+
+class PrimeNovoDatasetLoader(DatasetLoader):
+    """Loader for PrimeNovo predictions in TSV format.
+
+    PrimeNovo writes predictions to a tab-separated file with fixed columns
+    ``label``, ``prediction``, ``charge``, ``score``. Spectra (``.mgf``) are loaded
+    with matchms. ``spectrum_id`` is ``{experiment_name}:{title}`` on the MGF side and
+    ``{experiment_name}:{label}`` on the TSV side (PrimeNovo sets TSV ``label`` from the
+    MGF ``TITLE``). Titles and labels may be any non-empty string but must each be
+    unique within their file. Tables are inner-joined on ``spectrum_id``.
+
+    Score values are already probabilities in ``[0, 1]`` and are stored as
+    ``confidence`` without transformation. Beam predictions are not available from
+    PrimeNovo, so the returned :class:`CalibrationDataset` always has
+    ``predictions=None``.
+
+    ``mid_sequence_n_terminal_mods`` are matched as substrings of the raw TSV
+    ``prediction`` before remapping; use PrimeNovo compact notation, not UNIMOD.
+    """
+
+    # Score encoding: PrimeNovo ``score`` is a probability
+    _SCORE_MIN = 0.0
+    _SCORE_MAX = 1.0
+
+    def __init__(
+        self,
+        residue_masses: dict[str, float],
+        mid_sequence_n_terminal_mods: list[str],
+        residue_remapping: dict[str, str],
+        isotope_error_range: Tuple[int, int] = (0, 1),
+    ) -> None:
+        """Initialise the PrimeNovoDatasetLoader.
+
+        Args:
+            residue_masses: The mapping of residues to their masses (ProForma notation).
+            mid_sequence_n_terminal_mods: N-terminal modification tokens that are
+                invalid if they appear after residue position 0. Matched as
+                substrings of the raw TSV ``prediction`` **before**
+                ``residue_remapping``; use PrimeNovo compact notation (e.g.
+                ``[+42.011]``), not remapped UNIMOD forms. Matching rows are dropped.
+            residue_remapping: Optional ProForma mapping from PrimeNovo tokens.
+            isotope_error_range: The range of isotope errors to consider when matching
+                peptides.
+        """
+        self.metrics = Metrics(
+            residue_set=ResidueSet(
+                residue_masses=residue_masses, residue_remapping=residue_remapping
+            ),
+            isotope_error_range=isotope_error_range,
+        )
+        self.mid_sequence_n_terminal_mods = tuple(mid_sequence_n_terminal_mods)
+
+    @staticmethod
+    def _validate_join_keys(
+        spectrum_data: pl.DataFrame, predictions: pl.DataFrame
+    ) -> None:
+        """Validate normalised ``spectrum_id`` columns before joining."""
+        for name, df in (
+            ("spectrum data", spectrum_data),
+            ("predictions", predictions),
+        ):
+            if "spectrum_id" not in df.columns:
+                raise ValueError(f"{name} missing required 'spectrum_id' column.")
+
+        if spectrum_data["spectrum_id"].n_unique() != len(spectrum_data):
+            raise ValueError("Spectrum data 'spectrum_id' values must be unique.")
+
+        if predictions["spectrum_id"].n_unique() != len(predictions):
+            duplicates = (
+                predictions.group_by("spectrum_id")
+                .len()
+                .filter(pl.col("len") > 1)
+                .get_column("spectrum_id")
+                .head(5)
+                .to_list()
+            )
+            raise ValueError(
+                "Prediction 'spectrum_id' values must be unique (duplicate TSV "
+                f"label values). Duplicates: {duplicates}"
+            )
+
+        missing = (
+            predictions.select("spectrum_id")
+            .unique()
+            .join(
+                spectrum_data.select("spectrum_id").unique(),
+                on="spectrum_id",
+                how="anti",
+            )
+        )
+        if len(missing) > 0:
+            examples = missing["spectrum_id"].head(5).to_list()
+            raise ValueError(
+                "Predictions reference spectrum_id values not present in spectrum data: "
+                f"{examples}"
+            )
+
+    @classmethod
+    def _validate_primenovo_score(cls, score: float) -> None:
+        """Raise if a PrimeNovo score is outside ``[0, 1]``."""
+        if not cls._SCORE_MIN <= score <= cls._SCORE_MAX:
+            raise ValueError(
+                f"PrimeNovo scores must be probabilities in [0, 1]. Got {score}."
+            )
+
+    def load(
+        self, *, data_path: Path, predictions_path: Optional[Path] = None, **kwargs: Any
+    ) -> CalibrationDataset:
+        """Load a CalibrationDataset from PrimeNovo TSV predictions and MGF spectra.
+
+        Args:
+            data_path: Path to the spectrum data file (``.mgf`` only).
+            predictions_path: Path to the PrimeNovo predictions TSV file.
+            **kwargs: Not used.
+
+        Returns:
+            CalibrationDataset: Dataset containing merged metadata. ``predictions`` is
+                always ``None`` because PrimeNovo does not produce beams.
+
+        Raises:
+            ValueError: If ``predictions_path`` is None, required TSV columns are
+                missing, scores are outside ``[0, 1]``, MGF ``TITLE`` or TSV
+                ``label`` values are missing or not unique, or predictions
+                reference labels with no matching spectrum title.
+        """
+        if predictions_path is None:
+            raise ValueError("predictions_path is required for PrimeNovoDatasetLoader")
+
+        experiment_name = Path(data_path).stem
+        spectrum_data, has_labels = self._load_spectrum_data(data_path)
+
+        raw_predictions = self._load_predictions(predictions_path)
+        predictions = self._process_predictions(
+            raw_predictions,
+            spectrum_data.columns,
+            experiment_name,
+        )
+        metadata = self._merge_data(spectrum_data, predictions)
+
+        residue_remapping = self.metrics.residue_set.residue_remapping
+        metadata = data_utils.finalize_peptide_metadata(
+            metadata,
+            self.metrics,
+            has_labels=has_labels,
+            residue_remapping=residue_remapping,
+        )
+
+        metadata_pd = metadata.to_pandas()
+        # Polars List columns become numpy arrays under to_pandas(); CalibrationDataset
+        # and downstream features expect Python token lists (InstaNovo convention).
+        for column in ("prediction", "sequence"):
+            if column not in metadata_pd.columns:
+                continue
+            metadata_pd[column] = metadata_pd[column].apply(
+                lambda value: (
+                    value if isinstance(value, list) or value is None else list(value)
+                )
+            )
+
+        return CalibrationDataset(metadata=metadata_pd, predictions=None)
+
+    def _add_prediction_spectrum_ids(
+        self, predictions: pl.DataFrame, experiment_name: str
+    ) -> pl.DataFrame:
+        """Set prediction ``spectrum_id`` to ``{experiment_name}:{label}``.
+
+        PrimeNovo sets TSV ``label`` from the MGF ``TITLE``, so ids match
+        ``{experiment_name}:{title}`` on the spectrum side.
+        """
+        predictions = predictions.with_columns(
+            pl.col("label")
+            .map_elements(
+                lambda x: (
+                    str(x).strip()
+                    if x is not None and str(x).strip() != "" and str(x) != "nan"
+                    else None
+                ),
+                return_dtype=pl.Utf8,
+            )
+            .alias("label")
+        )
+        empty_labels = predictions.filter(pl.col("label").is_null())
+        if len(empty_labels) > 0:
+            raise ValueError(
+                "PrimeNovo predictions contain empty label values; label must equal "
+                "the corresponding MGF TITLE."
+            )
+
+        return predictions.with_columns(
+            (pl.lit(experiment_name) + ":" + pl.col("label")).alias("spectrum_id")
+        )
+
+    def _has_nterm_mod_in_middle(self, sequence: object) -> bool:
+        """Return True if sequence contains a configured N-terminal mod after position 0."""
+        if not isinstance(sequence, str):
+            return False
+        for modification in self.mid_sequence_n_terminal_mods:
+            if modification not in sequence:
+                continue
+            first_index = sequence.find(modification)
+            if first_index != 0:
+                return True
+            if sequence.find(modification, len(modification)) != -1:
+                return True
+        return False
+
+    def _load_predictions(self, predictions_path: Path | str) -> pl.DataFrame:
+        """Load PrimeNovo TSV predictions and validate required columns and scores.
+
+        Args:
+            predictions_path: Path to the predictions TSV or TXT file.
+
+        Returns:
+            DataFrame with the raw TSV columns (``label``, ``prediction``, ``score``,
+            and optional ``charge``).
+
+        Raises:
+            ValueError: If the file extension is not ``.tsv`` or ``.txt``, required
+                columns are absent, or any score is outside ``[0, 1]``.
+        """
+        predictions_path = Path(predictions_path)
+        if predictions_path.suffix not in {".tsv", ".txt"}:
+            raise ValueError(
+                f"Unsupported file format for PrimeNovo predictions: "
+                f"{predictions_path.suffix}. Supported formats are .tsv and .txt."
+            )
+        predictions = pl.read_csv(predictions_path, separator="\t")
+
+        required = ("label", "prediction", "score")
+        missing = [col for col in required if col not in predictions.columns]
+        if missing:
+            raise ValueError(
+                f"PrimeNovo predictions file is missing required column(s): {missing}. "
+                f"Present columns: {list(predictions.columns)}."
+            )
+
+        for score in predictions["score"]:
+            if score is not None:
+                self._validate_primenovo_score(float(score))
+
+        return predictions
+
+    def _load_spectrum_data(
+        self, spectrum_path: Path | str
+    ) -> Tuple[pl.DataFrame, bool]:
+        """Load MGF spectrum data and assign ``experiment_name`` / ``spectrum_id``.
+
+        Args:
+            spectrum_path: Path to the spectrum data file (``.mgf`` only).
+
+        Returns:
+            Tuple of (DataFrame containing spectrum data, whether ground truth labels
+            exist).
+
+        Raises:
+            ValueError: If the suffix is not ``.mgf``, any ``TITLE`` is missing, or
+                ``TITLE`` values are not unique within the file.
+        """
+        spectrum_path = Path(spectrum_path)
+
+        if spectrum_path.suffix != ".mgf":
+            raise ValueError(
+                f"Unsupported file format for spectrum data: {spectrum_path.suffix}. "
+                "Supported format is .mgf."
+            )
+
+        from matchms.importing import load_from_mgf
+
+        spectra = list(load_from_mgf(str(spectrum_path)))
+        df = data_utils.df_from_matchms(spectra)
+        titles = [spectrum.metadata.get("title") for spectrum in spectra]
+        df = df.with_columns(
+            pl.Series(
+                "title",
+                [
+                    (
+                        str(title).strip()
+                        if title is not None and str(title).strip() != ""
+                        else None
+                    )
+                    for title in titles
+                ],
+                dtype=pl.Utf8,
+            )
+        )
+
+        missing_titles = df.filter(pl.col("title").is_null())
+        if len(missing_titles) > 0:
+            raise ValueError(
+                "PrimeNovo MGF spectra require a non-empty TITLE for every ion. "
+                f"Missing TITLE on {len(missing_titles)} spectrum row(s)."
+            )
+        if df["title"].n_unique() != len(df):
+            duplicates = (
+                df.group_by("title")
+                .len()
+                .filter(pl.col("len") > 1)
+                .get_column("title")
+                .head(5)
+                .to_list()
+            )
+            raise ValueError(
+                "Spectrum TITLE values must be unique within an MGF file. "
+                f"Duplicate titles: {duplicates}"
+            )
+
+        experiment_name = spectrum_path.stem
+        df = df.with_columns(
+            pl.lit(experiment_name).alias("experiment_name").cast(pl.Utf8),
+            (pl.lit(experiment_name) + ":" + pl.col("title")).alias("spectrum_id"),
+        )
+
+        has_labels = data_utils.has_ground_truth_sequence_labels(df)
+        if "sequence" in df.columns and not has_labels:
+            df = df.drop("sequence")
+        return df, has_labels
+
+    def _merge_data(
+        self, spectrum_data: pl.DataFrame, predictions: pl.DataFrame
+    ) -> pl.DataFrame:
+        """Inner-join spectrum rows to predictions on ``spectrum_id``."""
+        self._validate_join_keys(spectrum_data, predictions)
+        merged = spectrum_data.join(predictions, on="spectrum_id", how="inner")
+
+        if merged.height == 0:
+            raise ValueError(
+                "PrimeNovo inner join on spectrum_id produced no rows. Ensure each "
+                "TSV label equals the corresponding spectrum TITLE in the MGF."
+            )
+        if merged.height != predictions.height:
+            raise ValueError(
+                f"Merge conflict: Expected {predictions.height} rows, "
+                f"but got {merged.height}."
+            )
+        return merged
+
+    def _process_predictions(
+        self,
+        predictions: pl.DataFrame,
+        spectrum_data_columns: list[str],
+        experiment_name: str,
+    ) -> pl.DataFrame:
+        """Assign ``spectrum_id``, filter mid-sequence N-term mods, and normalise columns.
+
+        Adds ``spectrum_id`` as ``{experiment_name}:{label}``, drops rows with
+        configured N-terminal mods mid-sequence, renames ``score`` to ``confidence``,
+        and sets ``prediction_untokenised``. Prediction columns that clash with
+        spectrum columns (except ``spectrum_id``) are dropped so spectrum metadata
+        wins.
+        """
+        predictions = self._add_prediction_spectrum_ids(predictions, experiment_name)
+
+        bad_mask = predictions.get_column("prediction").map_elements(
+            self._has_nterm_mod_in_middle,
+            return_dtype=pl.Boolean,
+        )
+        n_bad = int(bad_mask.sum())
+        if n_bad:
+            logger.warning(
+                "Filtered %d spectra with PrimeNovo N-terminal modifications "
+                "incorrectly placed in the middle of the peptide sequence.",
+                n_bad,
+            )
+            predictions = predictions.filter(~bad_mask)
+
+        predictions = predictions.rename({"score": "confidence"}).with_columns(
+            pl.col("prediction").alias("prediction_untokenised")
+        )
+
+        spectrum_columns = set(spectrum_data_columns)
+        return predictions.drop(
+            [
+                column
+                for column in predictions.columns
+                if column in spectrum_columns and column != "spectrum_id"
+            ]
+        )

--- a/winnow/datasets/data_loaders/utils.py
+++ b/winnow/datasets/data_loaders/utils.py
@@ -216,6 +216,11 @@ def _normalize_peptide_column_polars(
     )
 
 
+def _prediction_has_valid_score(value: object) -> bool:
+    """Return True when a confidence/score cell is present and non-NaN."""
+    return not is_missing_cell(value)
+
+
 def _row_evaluation_pandas(
     row: pd.Series,
     metrics: Metrics,
@@ -225,8 +230,8 @@ def _row_evaluation_pandas(
 ) -> tuple[int, bool]:
     sequence = as_token_list(row.get(sequence_col)) or []
     prediction = as_token_list(row.get(prediction_col)) or []
-    sequence_valid = is_valid_peptide_tokens(row.get(sequence_col))
-    prediction_valid = is_valid_peptide_tokens(row.get(prediction_col))
+    sequence_valid = bool(row["valid_sequence"])
+    prediction_valid = bool(row["valid_prediction"])
     num_matches = row_num_matches(
         sequence,
         prediction,
@@ -253,8 +258,8 @@ def _row_evaluation_polars(
 ) -> tuple[int, bool]:
     sequence = as_token_list(row.get(sequence_col)) or []
     prediction = as_token_list(row.get(prediction_col)) or []
-    sequence_valid = is_valid_peptide_tokens(row.get(sequence_col))
-    prediction_valid = is_valid_peptide_tokens(row.get(prediction_col))
+    sequence_valid = bool(row["valid_sequence"])
+    prediction_valid = bool(row["valid_prediction"])
     num_matches = row_num_matches(
         sequence,
         prediction,
@@ -272,6 +277,31 @@ def _row_evaluation_polars(
     return num_matches, correct
 
 
+def _apply_score_validity_pandas(
+    metadata: pd.DataFrame, score_col: str
+) -> pd.DataFrame:
+    if score_col not in metadata.columns:
+        return metadata
+    score_valid = metadata[score_col].map(_prediction_has_valid_score)
+    metadata["valid_prediction"] = metadata["valid_prediction"] & score_valid
+    return metadata
+
+
+def _apply_score_validity_polars(
+    metadata: pl.DataFrame, score_col: str
+) -> pl.DataFrame:
+    if score_col not in metadata.columns:
+        return metadata
+    score_valid = (
+        pl.col(score_col)
+        .map_elements(_prediction_has_valid_score, return_dtype=pl.Boolean)
+        .fill_null(False)
+    )
+    return metadata.with_columns(
+        (pl.col("valid_prediction") & score_valid).alias("valid_prediction")
+    )
+
+
 def _finalize_peptide_metadata_pandas(
     metadata: pd.DataFrame,
     metrics: Metrics,
@@ -280,6 +310,7 @@ def _finalize_peptide_metadata_pandas(
     residue_remapping: dict[str, str],
     sequence_col: str,
     prediction_col: str,
+    score_col: str,
 ) -> pd.DataFrame:
     metadata[prediction_col] = _normalize_peptide_column_pandas(
         metadata[prediction_col],
@@ -290,6 +321,7 @@ def _finalize_peptide_metadata_pandas(
     metadata["valid_prediction"] = metadata[prediction_col].apply(
         is_valid_peptide_tokens
     )
+    metadata = _apply_score_validity_pandas(metadata, score_col)
 
     if not has_labels:
         return metadata
@@ -326,6 +358,7 @@ def _finalize_peptide_metadata_polars(
     residue_remapping: dict[str, str],
     sequence_col: str,
     prediction_col: str,
+    score_col: str,
 ) -> pl.DataFrame:
     metadata = metadata.with_columns(
         _normalize_peptide_column_polars(
@@ -339,6 +372,7 @@ def _finalize_peptide_metadata_polars(
         .map_elements(is_valid_peptide_tokens, return_dtype=pl.Boolean)
         .alias("valid_prediction"),
     )
+    metadata = _apply_score_validity_polars(metadata, score_col)
 
     if not has_labels:
         return metadata
@@ -358,7 +392,7 @@ def _finalize_peptide_metadata_polars(
     )
 
     metadata = metadata.with_columns(
-        pl.struct([sequence_col, prediction_col])
+        pl.struct([sequence_col, prediction_col, "valid_sequence", "valid_prediction"])
         .map_elements(
             lambda row: dict(
                 zip(
@@ -391,12 +425,17 @@ def finalize_peptide_metadata(
     residue_remapping: dict[str, str] | None = None,
     sequence_col: str = "sequence",
     prediction_col: str = "prediction",
+    score_col: str = "confidence",
 ) -> DataFrameT:
     """Normalize peptide columns, set validity flags, and compute match columns.
 
     Accepts pandas or polars frames and returns the same frame type. All logic
     delegates to cell-level helpers so behaviour is identical regardless of
     whether cells arrive as ``list``, ``np.ndarray``, ``pl.Series``, or ``str``.
+
+    When ``score_col`` is present, rows with ``None``/NaN scores are marked
+    ``valid_prediction=False`` in addition to token-level checks. The score
+    check is skipped if the column is absent.
     """
     if residue_remapping is None:
         residue_remapping = metrics.residue_set.residue_remapping
@@ -409,6 +448,7 @@ def finalize_peptide_metadata(
             residue_remapping=residue_remapping,
             sequence_col=sequence_col,
             prediction_col=prediction_col,
+            score_col=score_col,
         )
     return _finalize_peptide_metadata_pandas(
         metadata,
@@ -417,6 +457,7 @@ def finalize_peptide_metadata(
         residue_remapping=residue_remapping,
         sequence_col=sequence_col,
         prediction_col=prediction_col,
+        score_col=score_col,
     )
 
 

--- a/winnow/datasets/data_loaders/winnow.py
+++ b/winnow/datasets/data_loaders/winnow.py
@@ -23,7 +23,7 @@ class WinnowDatasetLoader(DatasetLoader):
     def __init__(
         self,
         residue_masses: dict[str, float],
-        residue_remapping: dict[str, str],
+        residue_remapping: Optional[dict[str, str]] = None,
         isotope_error_range: Tuple[int, int] = (0, 1),
     ) -> None:
         """Initialise the WinnowDatasetLoader."""


### PR DESCRIPTION
## Summary

- Add `PrimeNovoDatasetLoader` for pi-PrimeNovo TSV predictions joined to MGF spectra, with Hydra config and unit tests.

Other small changes:
- Make `WinnowDatasetLoader.residue_remapping` optional so saved datasets can load without a remapping map.
- Tighten DatasetLoader API docs (valid constructor examples) and remove a no-op spectrum helper from the mzTab loader.

## Details

### PrimeNovo data loader

New module `winnow/datasets/data_loaders/primenovo.py` implements the `DatasetLoader` protocol for PrimeNovo outputs:

- **Inputs:** `.mgf` spectra (via matchms) and a TSV with fixed columns `label`, `prediction`, `charge`, `score`.
- **Join key:** both sides use `spectrum_id = {experiment_name}:{title|label}`, where `experiment_name` is the spectrum path stem and PrimeNovo copies MGF `TITLE` into the TSV `label` column. Inner join; spectra without a prediction are dropped; predictions with no matching spectrum raise.
- **Scores:** treated as probabilities in `[0, 1]` and stored as `confidence` without transformation. Out-of-range scores raise at load time.
- **Beams:** PrimeNovo does not emit beams, so `CalibrationDataset.predictions` is always `None`.
- **Peptide metadata:** shared `finalize_peptide_metadata` path (no per-loader tokenise/remap helpers).
- **N-terminal mods:** `mid_sequence_n_terminal_mods` matches substrings on the raw TSV `prediction` *before* remapping; rows with listed mods after position 0 are dropped. Config uses PrimeNovo compact notation (e.g. `[+42.011]`).

Wiring:

- Hydra config `winnow/configs/data_loader/primenovo.yaml` (residue remapping + mid-sequence filter list)
- Exported from `winnow.datasets.data_loaders`
- Listed as a `data_loader` option in `train` / `predict` / `compute_features` configs
- Docs section in `docs/api/datasets.md`

### Small fixes

- **`WinnowDatasetLoader`:** `residue_remapping` is now `Optional` with default `None`.
- **`MZTabDatasetLoader`:** expand `load()` docstring; drop unused `_process_spectrum_data` passthrough.
- **Docs:** DatasetLoader examples pass required `residue_masses` / remapping args so copy-paste snippets match the real constructors.