### PR TITLE
Run the test matrix across Python 3.10, 3.11, 3.12, and 3.13 on Linux, Windows and MacOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,11 @@ on:
       - main
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     env:
       # secrets cannot be referenced in step `if:` (schema); expose a boolean via env instead.
@@ -31,14 +32,14 @@ jobs:
         run: uv run pytest tests --verbose --cov=winnow --cov-report xml:coverage.xml --cov-report term-missing --junitxml=pytest.xml --cov-fail-under=0
       - name: pytest coverage comment
         id: coverageComment
-        if: matrix.python-version == '3.12'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: MishaKav/pytest-coverage-comment@287292879eaaff04116f36d3eb1a670f6e5df1a4
         with:
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: ./pytest.xml
       # Dependabot (and some fork PRs) do not receive Actions secrets; skip gist update to avoid 401.
       - name: Create the badge
-        if: env.HAS_BOT_TOKEN == 'true' && matrix.python-version == '3.12'
+        if: env.HAS_BOT_TOKEN == 'true' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483
         with:
           auth: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     env:
       # secrets cannot be referenced in step `if:` (schema); expose a boolean via env instead.
       HAS_BOT_TOKEN: ${{ secrets.BOT_ACCESS_TOKEN != '' }}
@@ -20,19 +24,21 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: "0.6.6"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync
       - name: Run tests with coverage
         run: uv run pytest tests --verbose --cov=winnow --cov-report xml:coverage.xml --cov-report term-missing --junitxml=pytest.xml --cov-fail-under=0
       - name: pytest coverage comment
         id: coverageComment
+        if: matrix.python-version == '3.12'
         uses: MishaKav/pytest-coverage-comment@287292879eaaff04116f36d3eb1a670f6e5df1a4
         with:
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: ./pytest.xml
       # Dependabot (and some fork PRs) do not receive Actions secrets; skip gist update to avoid 401.
       - name: Create the badge
-        if: env.HAS_BOT_TOKEN == 'true'
+        if: env.HAS_BOT_TOKEN == 'true' && matrix.python-version == '3.12'
         uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483
         with:
           auth: ${{ secrets.BOT_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR updates the CI to run the test matrix across Python 3.10, 3.11, 3.12, and 3.13 (matching `requires-python = ">=3.10,<3.14"` in `pyproject.toml`) on Linux, Windows and MacOS. 

- Added `strategy.matrix.python-version ` with `fail-fast: false ` so one version failing doesn't cancel the others.
- Passed `matrix.python-version` to  `astral-sh/setup-uv` so each job installs and tests against that interpreter.
- Gated the coverage-comment and badge steps to run only on the 3.12 on Linux leg, since they publish a single PR comment/badge. Running them on all 4 would post duplicates.