### PR TITLE
Fix PointNovo loader initialization on Python 3.10

### DIFF
--- a/winnow/datasets/data_loaders/pointnovo.py
+++ b/winnow/datasets/data_loaders/pointnovo.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.datasets.interfaces import DatasetLoader
@@ -14,6 +14,20 @@ class PointNovoDatasetLoader(DatasetLoader):
 
     Note: This loader is not yet implemented.
     """
+
+    def __init__(
+        self,
+        residue_masses: dict[str, float],
+        residue_remapping: Optional[dict[str, str]] = None,
+        isotope_error_range: Tuple[int, int] = (0, 1),
+    ) -> None:
+        """Initialise the loader with the common dataset-loader options.
+
+        The loader does not use these options until PointNovo support is implemented,
+        but defining the initializer makes this a concrete implementation of the
+        ``DatasetLoader`` protocol on Python 3.10.
+        """
+        del residue_masses, residue_remapping, isotope_error_range
 
     def load(
         self, *, data_path: Path, predictions_path: Optional[Path] = None, **kwargs: Any

--- a/winnow/datasets/data_loaders/pointnovo.py
+++ b/winnow/datasets/data_loaders/pointnovo.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any
 
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.datasets.interfaces import DatasetLoader
@@ -18,8 +18,8 @@ class PointNovoDatasetLoader(DatasetLoader):
     def __init__(
         self,
         residue_masses: dict[str, float],
-        residue_remapping: Optional[dict[str, str]] = None,
-        isotope_error_range: Tuple[int, int] = (0, 1),
+        residue_remapping: dict[str, str] | None = None,
+        isotope_error_range: tuple[int, int] = (0, 1),
     ) -> None:
         """Initialise the loader with the common dataset-loader options.
 
@@ -30,7 +30,7 @@ class PointNovoDatasetLoader(DatasetLoader):
         del residue_masses, residue_remapping, isotope_error_range
 
     def load(
-        self, *, data_path: Path, predictions_path: Optional[Path] = None, **kwargs: Any
+        self, *, data_path: Path, predictions_path: Path | None = None, **kwargs: Any
     ) -> CalibrationDataset:
         """Load a calibration dataset from PointNovo predictions."""
         raise NotImplementedError("PointNovoDatasetLoader is not yet implemented")


### PR DESCRIPTION
The Python 3.10 tests on Windows/Linux/MacOS are failing in https://github.com/instadeepai/winnow/pull/235.
This PR adds an `__init__()` to `PointNovoDatasetLoader` to make it a concrete implementation of the `DatasetLoader` protocol on Python 3.10.