### PR TITLE
Fix token_log_probabilities beam column example in the InstaNovo loader config

### DIFF
--- a/winnow/configs/data_loader/instanovo.yaml
+++ b/winnow/configs/data_loader/instanovo.yaml
@@ -33,12 +33,12 @@ residue_remapping:  # Used to map InstaNovo legacy notations to UNIMOD tokens.
 # Required columns per beam (where N is 0, 1, 2, ...):
 #   - {sequence}N         → peptide sequence for beam N (e.g., "predictions_beam_0")
 #   - {log_probability}N  → log probability for beam N  (e.g., "predictions_log_probability_beam_0")
-#   - {token_log_probabilities}N → per-token log probs  (e.g., "predictions_token_log_probabilities_0")
+#   - {token_log_probabilities}N → per-token log probs  (e.g., "predictions_token_log_probabilities_beam_0")
 #
 # Example CSV columns for 3 beams:
 #   predictions_beam_0, predictions_beam_1, predictions_beam_2,
 #   predictions_log_probability_beam_0, predictions_log_probability_beam_1, predictions_log_probability_beam_2,
-#   predictions_token_log_probabilities_0, predictions_token_log_probabilities_1, predictions_token_log_probabilities_2
+#   predictions_token_log_probabilities_beam_0, predictions_token_log_probabilities_beam_1, predictions_token_log_probabilities_beam_2
 #
 # Set `beam_columns` to null to disable beam loading entirely.
 # Column name mapping for the top-1 predictions CSV.


### PR DESCRIPTION
## What

`winnow/configs/data_loader/instanovo.yaml` documents the per-beam token-score column as `predictions_token_log_probabilities_0`, in two places, while the default prefix set 20 lines below is `predictions_token_log_probabilities_beam_`:

```yaml
# Required columns per beam (where N is 0, 1, 2, ...):
#   - {sequence}N         → ... (e.g., "predictions_beam_0")                      # correct
#   - {log_probability}N  → ... (e.g., "predictions_log_probability_beam_0")      # correct
#   - {token_log_probabilities}N → ... (e.g., "predictions_token_log_probabilities_0")   # missing beam_

beam_columns:
  sequence:                "predictions_beam_"
  log_probability:         "predictions_log_probability_beam_"
  token_log_probabilities: "predictions_token_log_probabilities_beam_"
```

The default is the correct one: InstaNovo writes `predictions_token_log_probabilities_beam_<i>`. I confirmed this against a real v1.2.2 beam-search run — the CSV has `predictions_beam_0..9`, `predictions_log_probability_beam_0..9` and `predictions_token_log_probabilities_beam_0..9`.

## Why it matters

The other two examples in the same comment block are right, so the third reads as authoritative rather than as a typo. Anyone naming their columns from it hits `_validate_beam_columns`:

```
Cannot find columns matching the following beam column prefixes in predictions file: [...]
```

which is a confusing place to discover the documentation was wrong — especially since the error lists the prefix it wanted, and it differs from the example by one token.

Comment only. No default, schema, or behaviour changes.

## Noted but not changed

`tests/datasets/data_loaders/test_instanovo.py` builds its loader fixture with an explicit override:

```python
beam_columns={
    "sequence": "predictions_beam_",
    "log_probability": "predictions_log_probability_beam_",
    "token_log_probabilities": "predictions_token_log_probabilities_",   # no beam_
}
```

so the suite is internally consistent and passes either way, but it never exercises the shipped default and encodes a prefix no real InstaNovo output uses. That's probably where the comment came from. Aligning the fixture with the default would make the tests cover the real convention — happy to do it here or in a follow-up, whichever you prefer; I left it out to keep this diff to the actual documentation bug.