### PR TITLE
Allow targeting a self-hosted Koina server

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -285,6 +285,8 @@ training (`calibrator.yaml` includes `defaults: - koina`) and explicitly for inf
 
 ```yaml
 koina:
+  server_url: koina.wilhelmlab.org:443
+  ssl: true
   intensity_model: Prosit_2025_intensity_22PTM
   irt_model: Prosit_2025_irt_22PTM
   input_constants:
@@ -299,9 +301,32 @@ koina:
 
 **Key parameters:**
 
+- `server_url` / `ssl`: Koina inference server to call. Defaults to the public endpoint; see [Self-hosting Koina](#self-hosting-koina) below
 - `intensity_model` / `irt_model`: Koina model identifiers (used when instantiating features at train time; saved in the checkpoint)
 - `input_constants` / `input_columns`: Collision energy and fragmentation type — **required at predict time** (not persisted in the checkpoint). Override with e.g. `koina.input_constants.collision_energies=30`
 - `constraints.*`: Validity filters interpolated into feature configs at train time
+
+#### Self-hosting Koina
+
+Every intensity and iRT feature is one call to a Koina server, so scoring a large dataset
+sends a great many predictions to the public endpoint. For bulk work, run your own
+[Koina](https://github.com/wilhelm-lab/koina) instance and point Winnow at it:
+
+```bash
+winnow predict \
+    koina.server_url=localhost:8500 \
+    koina.ssl=false \
+    dataset.spectrum_path_or_directory=data/spectra.mgf \
+    dataset.predictions_path=data/preds.csv
+```
+
+`ssl=false` is needed because a self-hosted Triton serves gRPC without TLS, whereas the
+public endpoint requires it. The same two overrides work for `train`, `compute-features`
+and `diagnose-calibration`.
+
+These settings are applied to features restored from a checkpoint as well as to features
+built from config, so a calibrator trained against the public endpoint -- including the
+pretrained general model -- can be used against a local server without retraining.
 
 ### Koina model input validation
 

--- a/tests/calibration/features/test_koina_server.py
+++ b/tests/calibration/features/test_koina_server.py
@@ -1,0 +1,53 @@
+"""Tests for targeting a self-hosted Koina server from the Koina-backed features."""
+
+import pytest
+
+from winnow.calibration.features.chimeric import ChimericFeatures
+from winnow.calibration.features.constants import DEFAULT_KOINA_SERVER_URL
+from winnow.calibration.features.fragment_match import FragmentMatchFeatures
+from winnow.calibration.features.retention_time import RetentionTimeFeature
+
+
+def _build(feature_class, **kwargs):
+    """Construct a feature, supplying whichever required arguments it has."""
+    if feature_class is RetentionTimeFeature:
+        return feature_class(**kwargs)
+    return feature_class(mz_tolerance=0.02, mz_tolerance_unit="da", **kwargs)
+
+
+KOINA_FEATURES = [FragmentMatchFeatures, ChimericFeatures, RetentionTimeFeature]
+
+
+def test_default_server_url_is_the_public_endpoint():
+    """The fallback used when no server is configured is the public Koina endpoint."""
+    assert DEFAULT_KOINA_SERVER_URL == "koina.wilhelmlab.org:443"
+
+
+@pytest.mark.parametrize("feature_class", KOINA_FEATURES)
+def test_server_is_unset_by_default(feature_class):
+    """Without configuration a feature carries no server, so the public one is used."""
+    feature = _build(feature_class)
+
+    assert feature.koina_server_url is None
+    assert feature.koina_ssl is True
+
+
+@pytest.mark.parametrize("feature_class", KOINA_FEATURES)
+def test_self_hosted_server_is_stored(feature_class):
+    """A self-hosted server and its TLS setting are kept for the Koina client."""
+    feature = _build(feature_class, koina_server_url="localhost:8500", koina_ssl=False)
+
+    assert feature.koina_server_url == "localhost:8500"
+    assert feature.koina_ssl is False
+
+
+@pytest.mark.parametrize("feature_class", KOINA_FEATURES)
+def test_server_can_be_overridden_after_construction(feature_class):
+    """Features restored from a checkpoint are retargeted by assignment."""
+    feature = _build(feature_class)
+
+    feature.koina_server_url = "localhost:8500"
+    feature.koina_ssl = False
+
+    assert feature.koina_server_url == "localhost:8500"
+    assert feature.koina_ssl is False

--- a/tests/calibration/features/test_koina_server.py
+++ b/tests/calibration/features/test_koina_server.py
@@ -51,3 +51,36 @@ def test_server_can_be_overridden_after_construction(feature_class):
 
     assert feature.koina_server_url == "localhost:8500"
     assert feature.koina_ssl is False
+
+
+@pytest.mark.parametrize("feature_class", KOINA_FEATURES)
+def test_feature_restored_without_the_settings_still_resolves_them(feature_class):
+    """A checkpoint predating these settings must not raise on first use.
+
+    Features are restored by unpickling, which only repopulates whatever the saved
+    state contained, so instances from an older checkpoint carry neither attribute.
+    """
+    feature = feature_class.__new__(feature_class)
+
+    assert feature.koina_server_url is None
+    assert feature.koina_ssl is True
+
+
+@pytest.mark.parametrize("feature_class", KOINA_FEATURES)
+def test_feature_restored_without_the_settings_is_still_retargetable(feature_class):
+    """Such a feature must still be visible to apply_koina_server_overrides.
+
+    That override skips objects lacking the attributes, so without class-level
+    defaults a legacy feature would be passed over silently and keep calling the
+    public endpoint.
+    """
+    feature = feature_class.__new__(feature_class)
+
+    assert hasattr(feature, "koina_server_url")
+    assert hasattr(feature, "koina_ssl")
+
+    feature.koina_server_url = "localhost:8500"
+    feature.koina_ssl = False
+
+    assert feature.koina_server_url == "localhost:8500"
+    assert feature.koina_ssl is False

--- a/tests/calibration/test_calibrator.py
+++ b/tests/calibration/test_calibrator.py
@@ -71,6 +71,8 @@ class MockKoinaFeature(MockCalibrationFeature):
         super().__init__("mock_koina", ["kcol"])
         self.model_input_constants = {"collision_energies": 20}
         self.model_input_columns = {"fragmentation_types": "frag_col"}
+        self.koina_server_url = None
+        self.koina_ssl = True
 
 
 class DeterministicMockFeature(MockCalibrationFeature):
@@ -306,6 +308,41 @@ class TestProbabilityCalibrator:
         assert calibrator.seed == 123
         assert calibrator.val_early_stopping_max_psms is None
         assert calibrator.val_subsample_seed is None
+
+    def test_apply_koina_server_overrides(self):
+        """Inference-time Koina server overrides reach every Koina-using feature."""
+        calibrator = ProbabilityCalibrator()
+        calibrator.add_feature(MockKoinaFeature())
+        calibrator.apply_koina_server_overrides(server_url="localhost:8500", ssl=False)
+        feat = calibrator.feature_dict["mock_koina"]
+        assert feat.koina_server_url == "localhost:8500"
+        assert feat.koina_ssl is False
+
+    def test_apply_koina_server_overrides_is_a_noop_when_unset(self):
+        """Passing neither value leaves the feature untouched."""
+        calibrator = ProbabilityCalibrator()
+        calibrator.add_feature(MockKoinaFeature())
+        calibrator.apply_koina_server_overrides()
+        feat = calibrator.feature_dict["mock_koina"]
+        assert feat.koina_server_url is None
+        assert feat.koina_ssl is True
+
+    def test_apply_koina_server_overrides_accepts_one_value(self):
+        """Only the supplied value changes; the other keeps its current setting."""
+        calibrator = ProbabilityCalibrator()
+        calibrator.add_feature(MockKoinaFeature())
+        calibrator.apply_koina_server_overrides(server_url="localhost:8500")
+        feat = calibrator.feature_dict["mock_koina"]
+        assert feat.koina_server_url == "localhost:8500"
+        assert feat.koina_ssl is True
+
+    def test_apply_koina_server_overrides_skips_non_koina_features(self):
+        """Features without Koina attributes are left alone rather than raising."""
+        calibrator = ProbabilityCalibrator()
+        calibrator.add_feature(MockCalibrationFeature("plain", ["c"]))
+        calibrator.apply_koina_server_overrides(server_url="localhost:8500", ssl=False)
+        feat = calibrator.feature_dict["plain"]
+        assert not hasattr(feat, "koina_server_url")
 
     def test_apply_koina_model_input_overrides(self):
         """Inference-time Koina constant/column overrides merge into features."""

--- a/tests/configs/test_koina_config.py
+++ b/tests/configs/test_koina_config.py
@@ -1,0 +1,48 @@
+"""Tests for the shared Koina configuration."""
+
+from pathlib import Path
+
+from omegaconf import OmegaConf
+
+CONFIG_DIR = Path(__file__).parents[2] / "winnow" / "configs"
+
+
+def test_koina_config_defaults_to_the_public_endpoint():
+    """The default server is the public Koina endpoint, over TLS."""
+    cfg = OmegaConf.load(CONFIG_DIR / "koina.yaml")
+
+    assert cfg.koina.server_url == "koina.wilhelmlab.org:443"
+    assert cfg.koina.ssl is True
+
+
+def test_calibrator_interpolates_the_koina_server_into_koina_features():
+    """Features calling Koina take their server from the shared block."""
+    cfg = OmegaConf.load(CONFIG_DIR / "calibrator.yaml")
+    features = cfg.calibrator.features
+
+    koina_features = [
+        name
+        for name, feature in features.items()
+        if feature is not None and "koina_server_url" in feature
+    ]
+    assert koina_features, "expected at least one Koina-backed feature"
+
+    for name in koina_features:
+        assert (
+            features[name]._get_node("koina_server_url")._value()
+            == "${koina.server_url}"
+        ), name
+        assert features[name]._get_node("koina_ssl")._value() == "${koina.ssl}", name
+
+
+def test_every_feature_naming_a_koina_model_also_names_a_server():
+    """A feature that calls a Koina model must say which server to call."""
+    cfg = OmegaConf.load(CONFIG_DIR / "calibrator.yaml")
+
+    for name, feature in cfg.calibrator.features.items():
+        if feature is None:
+            continue
+        keys = set(feature.keys())
+        if {"intensity_model_name", "irt_model_name"} & keys:
+            assert "koina_server_url" in keys, name
+            assert "koina_ssl" in keys, name

--- a/winnow/calibration/calibrator.py
+++ b/winnow/calibration/calibrator.py
@@ -524,6 +524,36 @@ class ProbabilityCalibrator:
         calibrator._validate_loaded_checkpoint(input_dim)
         return calibrator
 
+    def apply_koina_server_overrides(
+        self,
+        server_url: Optional[str] = None,
+        ssl: Optional[bool] = None,
+    ) -> None:
+        """Override the Koina inference server on every Koina-using feature.
+
+        Lets a self-hosted Koina/Triton instance be targeted without retraining, since
+        features restored from a checkpoint carry whatever server was configured when
+        the calibrator was trained.
+
+        Args:
+            server_url: Koina inference server URL (e.g. "localhost:8500"). When None,
+                features keep their current value.
+            ssl: Whether to use SSL when talking to the Koina server. When None,
+                features keep their current value.
+        """
+        if server_url is None and ssl is None:
+            return
+
+        for feature in self.feature_dict.values():
+            if not (
+                hasattr(feature, "koina_server_url") and hasattr(feature, "koina_ssl")
+            ):
+                continue
+            if server_url is not None:
+                feature.koina_server_url = server_url
+            if ssl is not None:
+                feature.koina_ssl = ssl
+
     def apply_koina_model_input_overrides(
         self,
         model_input_constants: Optional[Dict[str, Any]] = None,

--- a/winnow/calibration/features/chimeric.py
+++ b/winnow/calibration/features/chimeric.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 import koinapy
 
+from winnow.calibration.features.constants import DEFAULT_KOINA_SERVER_URL
 from winnow.calibration.features.base import CalibrationFeatures, FeatureDependency
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.calibration.features.utils import (
@@ -37,6 +38,8 @@ class ChimericFeatures(CalibrationFeatures):
         unsupported_residues: Optional[List[str]] = None,
         model_input_constants: Optional[Dict[str, Any]] = None,
         model_input_columns: Optional[Dict[str, str]] = None,
+        koina_server_url: Optional[str] = None,
+        koina_ssl: bool = True,
     ) -> None:
         """Initialize ChimericFeatures.
 
@@ -65,6 +68,13 @@ class ChimericFeatures(CalibrationFeatures):
                 metadata column name that provides per-row values
                 (e.g. {"collision_energies": "nce_col"}). Defaults to None.
 
+            koina_server_url (Optional[str]): URL of the Koina inference server
+                (e.g. "localhost:8500" for a self-hosted instance). When None, the
+                public endpoint at koina.wilhelmlab.org:443 is used. Defaults to None.
+            koina_ssl (bool): Whether to use SSL when talking to the Koina server. Set
+                to False for a self-hosted server, which Triton serves without TLS.
+                Defaults to True.
+
         Raises:
             ValueError: If ``mz_tolerance`` is not numeric, ``mz_tolerance_unit`` is invalid,
                 or the same key appears in both model_input_constants and model_input_columns.
@@ -82,6 +92,8 @@ class ChimericFeatures(CalibrationFeatures):
         self.max_peptide_length = max_peptide_length
         self.model_input_constants = model_input_constants
         self.model_input_columns = model_input_columns
+        self.koina_server_url = koina_server_url
+        self.koina_ssl = koina_ssl
 
     @property
     def dependencies(self) -> List[FeatureDependency]:
@@ -270,7 +282,11 @@ class ChimericFeatures(CalibrationFeatures):
         )
         inputs.index = valid_chimeric_prosit_input.metadata["spectrum_id"]
 
-        model = koinapy.Koina(self.prosit_intensity_model_name)
+        model = koinapy.Koina(
+            self.prosit_intensity_model_name,
+            server_url=self.koina_server_url or DEFAULT_KOINA_SERVER_URL,
+            ssl=self.koina_ssl,
+        )
         inputs = resolve_model_inputs(
             inputs=inputs,
             metadata=valid_chimeric_prosit_input.metadata,

--- a/winnow/calibration/features/chimeric.py
+++ b/winnow/calibration/features/chimeric.py
@@ -26,6 +26,12 @@ class ChimericFeatures(CalibrationFeatures):
     Predicts ion intensities for runner-up (second-best) peptide sequences using a Koina intensity model.
     """
 
+    # Class-level defaults so instances unpickled from checkpoints that predate these
+    # settings still resolve them, rather than raising AttributeError on first use.
+    # Instances set their own values in __init__; assignment still overrides per feature.
+    koina_server_url: Optional[str] = None
+    koina_ssl: bool = True
+
     def __init__(
         self,
         *,

--- a/winnow/calibration/features/constants.py
+++ b/winnow/calibration/features/constants.py
@@ -7,6 +7,9 @@ H2O_MASS = 18.0106
 PROTON_MASS = 1.007276
 
 VALID_INTENSITY_MODEL_PROVIDERS = ["prosit", "ms2pip", "alphapeptdeep"]
+# Public Koina endpoint. Features fall back to this when no server is configured,
+# which keeps behaviour identical for anyone not self-hosting.
+DEFAULT_KOINA_SERVER_URL = "koina.wilhelmlab.org:443"
 # Default bin width matching Comet's fragment_bin_tol for near-unit-dalton bins.
 XCORR_BIN_SIZE = 1.0005079
 # Default bin offset matching Comet's fragment_bin_offset.

--- a/winnow/calibration/features/fragment_match.py
+++ b/winnow/calibration/features/fragment_match.py
@@ -4,6 +4,7 @@ import pandas as pd
 import numpy as np
 import koinapy
 
+from winnow.calibration.features.constants import DEFAULT_KOINA_SERVER_URL
 from winnow.calibration.features.base import CalibrationFeatures, FeatureDependency
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.calibration.features.utils import (
@@ -37,6 +38,8 @@ class FragmentMatchFeatures(CalibrationFeatures):
         unsupported_residues: Optional[List[str]] = None,
         model_input_constants: Optional[Dict[str, Any]] = None,
         model_input_columns: Optional[Dict[str, str]] = None,
+        koina_server_url: Optional[str] = None,
+        koina_ssl: bool = True,
     ) -> None:
         """Initialize FragmentMatchFeatures.
 
@@ -66,6 +69,13 @@ class FragmentMatchFeatures(CalibrationFeatures):
                 metadata column name that provides per-row values
                 (e.g. {"collision_energies": "nce_col"}). Defaults to None.
 
+            koina_server_url (Optional[str]): URL of the Koina inference server
+                (e.g. "localhost:8500" for a self-hosted instance). When None, the
+                public endpoint at koina.wilhelmlab.org:443 is used. Defaults to None.
+            koina_ssl (bool): Whether to use SSL when talking to the Koina server. Set
+                to False for a self-hosted server, which Triton serves without TLS.
+                Defaults to True.
+
         Raises:
             ValueError: If ``mz_tolerance`` is not numeric, ``mz_tolerance_unit`` is invalid,
                 or the same key appears in both model_input_constants and model_input_columns.
@@ -83,6 +93,8 @@ class FragmentMatchFeatures(CalibrationFeatures):
         self.max_peptide_length = max_peptide_length
         self.model_input_constants = model_input_constants
         self.model_input_columns = model_input_columns
+        self.koina_server_url = koina_server_url
+        self.koina_ssl = koina_ssl
 
     @property
     def dependencies(self) -> List[FeatureDependency]:
@@ -253,7 +265,11 @@ class FragmentMatchFeatures(CalibrationFeatures):
         inputs["precursor_charges"] = np.array(valid_input.metadata["precursor_charge"])
         inputs.index = valid_input.metadata["spectrum_id"]
 
-        model = koinapy.Koina(self.intensity_model_name)
+        model = koinapy.Koina(
+            self.intensity_model_name,
+            server_url=self.koina_server_url or DEFAULT_KOINA_SERVER_URL,
+            ssl=self.koina_ssl,
+        )
 
         # Append any additional input columns required by the model
         inputs = resolve_model_inputs(

--- a/winnow/calibration/features/fragment_match.py
+++ b/winnow/calibration/features/fragment_match.py
@@ -26,6 +26,12 @@ class FragmentMatchFeatures(CalibrationFeatures):
     the observed spectrum.
     """
 
+    # Class-level defaults so instances unpickled from checkpoints that predate these
+    # settings still resolve them, rather than raising AttributeError on first use.
+    # Instances set their own values in __init__; assignment still overrides per feature.
+    koina_server_url: Optional[str] = None
+    koina_ssl: bool = True
+
     def __init__(
         self,
         *,

--- a/winnow/calibration/features/retention_time.py
+++ b/winnow/calibration/features/retention_time.py
@@ -23,6 +23,12 @@ class RetentionTimeFeature(CalibrationFeatures):
     inference time using self-supervised data (no database labels needed).
     """
 
+    # Class-level defaults so instances unpickled from checkpoints that predate these
+    # settings still resolve them, rather than raising AttributeError on first use.
+    # Instances set their own values in __init__; assignment still overrides per feature.
+    koina_server_url: Optional[str] = None
+    koina_ssl: bool = True
+
     def __init__(
         self,
         train_fraction: float = 0.1,

--- a/winnow/calibration/features/retention_time.py
+++ b/winnow/calibration/features/retention_time.py
@@ -8,6 +8,7 @@ import numpy as np
 import warnings
 import koinapy
 
+from winnow.calibration.features.constants import DEFAULT_KOINA_SERVER_URL
 from winnow.calibration.features.base import CalibrationFeatures, FeatureDependency
 from winnow.datasets.calibration_dataset import CalibrationDataset
 from winnow.utils.peptide import as_token_list, tokens_to_proforma
@@ -31,6 +32,8 @@ class RetentionTimeFeature(CalibrationFeatures):
         irt_model_name: str = "Prosit_2019_irt",
         max_peptide_length: int = 30,
         unsupported_residues: Optional[List[str]] = None,
+        koina_server_url: Optional[str] = None,
+        koina_ssl: bool = True,
     ) -> None:
         """Initialize RetentionTimeFeature.
 
@@ -63,6 +66,8 @@ class RetentionTimeFeature(CalibrationFeatures):
         )
         self.irt_model_name = irt_model_name
         self.max_peptide_length = max_peptide_length
+        self.koina_server_url = koina_server_url
+        self.koina_ssl = koina_ssl
         self.irt_predictors: Dict[str, LinearRegression] = {}
         self._loaded_experiment_names: Set[str] = set()
         self._skipped_experiments: List[str] = []
@@ -257,7 +262,11 @@ class RetentionTimeFeature(CalibrationFeatures):
             [tokens_to_proforma(peptide) for peptide in all_train["prediction"]]
         )
 
-        koina_model = koinapy.Koina(self.irt_model_name)
+        koina_model = koinapy.Koina(
+            self.irt_model_name,
+            server_url=self.koina_server_url or DEFAULT_KOINA_SERVER_URL,
+            ssl=self.koina_ssl,
+        )
         irt_predictions = koina_model.predict(inputs)
         all_irt = irt_predictions["irt"].values
 
@@ -313,7 +322,11 @@ class RetentionTimeFeature(CalibrationFeatures):
         )
         inputs.index = valid_irt_input.metadata["spectrum_id"]
 
-        koina_model = koinapy.Koina(self.irt_model_name)
+        koina_model = koinapy.Koina(
+            self.irt_model_name,
+            server_url=self.koina_server_url or DEFAULT_KOINA_SERVER_URL,
+            ssl=self.koina_ssl,
+        )
         predictions = koina_model.predict(inputs)
         predictions["spectrum_id"] = predictions.index
 

--- a/winnow/configs/calibrator.yaml
+++ b/winnow/configs/calibrator.yaml
@@ -41,6 +41,8 @@ calibrator:
       mz_tolerance_unit: ppm
       learn_from_missing: false  # If True, impute missing features and add an indicator column. If False, filter invalid entries with a warning.
       intensity_model_name: ${koina.intensity_model}  # The name of the Koina intensity model to use.
+      koina_server_url: ${koina.server_url}
+      koina_ssl: ${koina.ssl}
       max_precursor_charge: ${koina.constraints.max_precursor_charge}  # Maximum precursor charge accepted by the Koina intensity model.
       max_peptide_length: ${koina.constraints.max_peptide_length}      # Maximum peptide length accepted by the Koina intensity model.
       unsupported_residues: ${koina.constraints.unsupported_residues}  # Residues unsupported by the configured Koina intensity model.
@@ -54,5 +56,7 @@ calibrator:
       learn_from_missing: false  # If True, impute missing features and add an indicator column. If False, filter invalid entries with a warning.
       seed: 42  # Random seed for reproducibility.
       irt_model_name: ${koina.irt_model}  # The name of the Koina iRT model to use.
+      koina_server_url: ${koina.server_url}
+      koina_ssl: ${koina.ssl}
       max_peptide_length: ${koina.constraints.max_peptide_length}      # Maximum peptide length accepted by the Koina iRT model.
       unsupported_residues: ${koina.constraints.unsupported_residues}  # Residues unsupported by the configured Koina iRT model.

--- a/winnow/configs/koina.yaml
+++ b/winnow/configs/koina.yaml
@@ -5,6 +5,11 @@
 # are merged from this block (see winnow predict).
 
 koina:
+  # Inference server. Override to e.g. `localhost:8500` with `ssl: false` when running
+  # a self-hosted Koina/Triton instance; the default is the public endpoint.
+  server_url: koina.wilhelmlab.org:443
+  ssl: true
+
   # Model names
   intensity_model: Prosit_2025_intensity_22PTM
   irt_model: Prosit_2025_irt_22PTM

--- a/winnow/utils/koina_intensity_config.py
+++ b/winnow/utils/koina_intensity_config.py
@@ -201,6 +201,12 @@ def apply_koina_intensity_config(
     if koina_cfg is None:
         return
 
+    server_url = koina_cfg.get("server_url")
+    ssl = koina_cfg.get("ssl")
+    if server_url is not None or ssl is not None:
+        logger.info("Koina server: %s (ssl=%s)", server_url, ssl)
+    calibrator.apply_koina_server_overrides(server_url=server_url, ssl=ssl)
+
     constants, columns = parse_koina_intensity_config(koina_cfg)
     calibrator.apply_koina_model_input_overrides(
         model_input_constants=constants,


### PR DESCRIPTION
## Problem

The Koina-backed features build their client with no server argument:

```python
model = koinapy.Koina(self.intensity_model_name)          # fragment_match.py
model = koinapy.Koina(self.prosit_intensity_model_name)   # chimeric.py
koina_model = koinapy.Koina(self.irt_model_name)          # retention_time.py
```

so every intensity and iRT prediction goes to the public endpoint at `koina.wilhelmlab.org`, and there is no configuration hook to change it. That makes bulk work impractical. 

## Change

Adds `koina.server_url` and `koina.ssl`, defaulting to the public endpoint, so **behaviour is unchanged for anyone not self-hosting**:

```bash
winnow diagnose-calibration \
    koina.server_url=localhost:8500 \
    koina.ssl=false \
    dataset.spectrum_path_or_directory=data/spectra.mgf \
    dataset.predictions_path=data/preds.csv
```

- `FragmentMatchFeatures`, `ChimericFeatures` and `RetentionTimeFeature` take `koina_server_url` / `koina_ssl` and pass them to `koinapy.Koina`, falling back to a new `DEFAULT_KOINA_SERVER_URL`.
- `ProbabilityCalibrator.apply_koina_server_overrides` sets them on **restored** features, mirroring the existing `apply_koina_model_input_overrides`. With a pretrained calibrator the features come from the checkpoint, not from `calibrator.yaml`, so config wiring alone would have no effect. It means the pretrained general model can be used against a local server without retraining.
- `apply_koina_intensity_config` applies it where it already applies the model-input overrides, so every command reading the `koina` block picks it up with no CLI changes.
- `calibrator.yaml` interpolates the keys for the training path.

`ssl=false` is required because a self-hosted Triton serves gRPC without TLS while the public endpoint requires it, so the two settings have to travel together.

## Tests

- `tests/configs/test_koina_config.py` — the shipped config defaults to the public endpoint, every feature naming a Koina model also names a server, and the interpolations are the expected `${koina.*}` references.
- `tests/calibration/test_calibrator.py` — `apply_koina_server_overrides` retargets a Koina feature, is a no-op when given neither value, accepts one value without clobbering the other, and skips features that do not call Koina.
- `tests/calibration/features/test_koina_server.py` — all three feature classes default to no server, store a self-hosted one, and can be retargeted by assignment after construction.

## Docs

`docs/configuration.md` gains a "Self-hosting Koina" section with the overrides, why `ssl` must be disabled locally, and a note that the settings apply to checkpoint-restored features too. The Koina config reference lists the new keys.